### PR TITLE
bug fixes & network print?

### DIFF
--- a/src/model/network-simple-multicast.cpp
+++ b/src/model/network-simple-multicast.cpp
@@ -89,6 +89,31 @@ SimpleMulticastNetwork::Specs SimpleMulticastNetwork::ParseSpecs(config::Compoun
     specs.word_bits = Specs::kDefaultWordBits;
   }
 
+  // user-defined action name
+  std::string action_name;
+  if (network.lookupValue("action_name", action_name)){
+     specs.action_name = action_name;
+  } else {
+     std::cerr << "must specify the multicast action_name to look for in ERT" << std::endl;
+     assert(false); // FIXME: perform the default multicast energy calculations
+  }
+
+  // user-defined argument name corresponding to the multicast factor
+  std::string multicast_factor_argument;
+  if (network.lookupValue("multicast_factor_argument", multicast_factor_argument)){
+     specs.multicast_factor_argument = multicast_factor_argument;
+  } else {
+     specs.multicast_factor_argument = "none";
+  }
+
+  // whether ERT specification is in terms of data types
+  bool per_datatype_ERT;
+  if (network.lookupValue("per_datatype_ERT", per_datatype_ERT)){
+    per_datatype_ERT = true;
+  } else {
+    per_datatype_ERT = false;
+  }
+
   return specs;
 }
 
@@ -138,21 +163,20 @@ void SimpleMulticastNetwork::SetTileWidth(double width_um)
   }
 }
 
-// Parse ERT to get multi-casting energy
-double SimpleMulticastNetwork::GetMulticastEnergy(std::uint64_t multicast_factor, std::string data_space_name){
-    std::vector<std::string> actions;
-    std::string operation_name = "transfer_" + data_space_name;
+double SimpleMulticastNetwork::GetOpEnergyFromERT(std::uint64_t multicast_factor, std::string operation_name){
     double opEnergy = 0.0;
+    std::vector<std::string> actions;
     specs_.accelergyERT.getMapKeys(actions);
     // use transfer as the keyword for multicast NoC action specification
     if (specs_.accelergyERT.exists(operation_name)){
         auto actionERT = specs_.accelergyERT.lookup(operation_name);
         if (actionERT.isList()){
+            assert(specs_.multicast_factor_argument != "none"); // must have multicast factor argument name specified
             for(int i = 0; i < actionERT.getLength(); i ++){
                 config::CompoundConfigNode arguments = actionERT[i].lookup("arguments");
                 unsigned int num_destinations;
                 // use num_destinations as a keyword to perform ERT search (might be updated)
-                arguments.lookupValue("num_destinations", num_destinations);
+                arguments.lookupValue(specs_.multicast_factor_argument, num_destinations);
                 if (num_destinations == multicast_factor){
                   // std::cout << "found correct num destinations" << std::endl;
                   actionERT[i].lookupValue("energy", opEnergy);
@@ -163,6 +187,19 @@ double SimpleMulticastNetwork::GetMulticastEnergy(std::uint64_t multicast_factor
             actionERT.lookupValue("energy", opEnergy);
         }
     }
+    return opEnergy;
+}
+
+double SimpleMulticastNetwork::GetMulticastEnergy(std::uint64_t multicast_factor){
+    std::string operation_name = specs_.action_name;
+    double opEnergy = GetOpEnergyFromERT(multicast_factor, operation_name);
+    return opEnergy;
+}
+
+// Parse ERT to get multi-casting energy
+double SimpleMulticastNetwork::GetMulticastEnergyByDataType(std::uint64_t multicast_factor, std::string data_space_name){
+    std::string operation_name = specs_.action_name + "_" + data_space_name;
+    double opEnergy = GetOpEnergyFromERT(multicast_factor, operation_name);
     return opEnergy;
 }
 
@@ -194,7 +231,11 @@ EvalStatus SimpleMulticastNetwork::Evaluate(const tiling::CompoundTile& tile,
       if (ingresses > 0)
       {
         auto multicast_factor = i + 1;
-        stats_.energy[pv] = GetMulticastEnergy(multicast_factor, data_space_name) * ingresses;
+        if (specs_.per_datatype_ERT){
+          stats_.energy[pv] = GetMulticastEnergyByDataType(multicast_factor, data_space_name) * ingresses;
+        } else {
+          stats_.energy[pv] = GetMulticastEnergy(multicast_factor) * ingresses;
+        }
         stats_.multicast_factor[pv] = multicast_factor;
       }
     }
@@ -220,6 +261,7 @@ void SimpleMulticastNetwork::Print(std::ostream& out) const
   out << indent << indent << "Type            : " << specs_.type << std::endl;
   out << indent << indent << "ConnectionType  : " << specs_.cType << std::endl;
   out << indent << indent << "Word bits       : " << specs_.word_bits << std::endl;
+  out << indent << indent << "Action Name       : " << specs_.action_name << std::endl;
 
   out << std::endl;
 

--- a/src/model/network-simple-multicast.cpp
+++ b/src/model/network-simple-multicast.cpp
@@ -139,13 +139,14 @@ void SimpleMulticastNetwork::SetTileWidth(double width_um)
 }
 
 // Parse ERT to get multi-casting energy
-double SimpleMulticastNetwork::GetMulticastEnergy(std::uint64_t multicast_factor){
+double SimpleMulticastNetwork::GetMulticastEnergy(std::uint64_t multicast_factor, std::string data_space_name){
     std::vector<std::string> actions;
+    std::string operation_name = "transfer_" + data_space_name;
     double opEnergy = 0.0;
     specs_.accelergyERT.getMapKeys(actions);
     // use transfer as the keyword for multicast NoC action specification
-    if (specs_.accelergyERT.exists("transfer")){
-        auto actionERT = specs_.accelergyERT.lookup("transfer");
+    if (specs_.accelergyERT.exists(operation_name)){
+        auto actionERT = specs_.accelergyERT.lookup(operation_name);
         if (actionERT.isList()){
             for(int i = 0; i < actionERT.getLength(); i ++){
                 config::CompoundConfigNode arguments = actionERT[i].lookup("arguments");
@@ -179,6 +180,7 @@ EvalStatus SimpleMulticastNetwork::Evaluate(const tiling::CompoundTile& tile,
     stats_.fanout = tile[pvi].fanout;
     stats_.multicast_factor[pv] = 0;
 
+    std::string data_space_name = problem::GetShape()->DataSpaceIDToName.at(pvi);
     // don't care what type of connection this is
     // only need to count the number of transfers
     stats_.ingresses[pv].resize(tile[pvi].accesses.size());
@@ -192,7 +194,7 @@ EvalStatus SimpleMulticastNetwork::Evaluate(const tiling::CompoundTile& tile,
       if (ingresses > 0)
       {
         auto multicast_factor = i + 1;
-        stats_.energy[pv] = GetMulticastEnergy(multicast_factor) * ingresses;
+        stats_.energy[pv] = GetMulticastEnergy(multicast_factor, data_space_name) * ingresses;
         stats_.multicast_factor[pv] = multicast_factor;
       }
     }

--- a/src/model/network-simple-multicast.hpp
+++ b/src/model/network-simple-multicast.hpp
@@ -161,7 +161,7 @@ class SimpleMulticastNetwork : public Network
   void SetTileWidth(double width_um);
 
   // Parse ERT to get multi-casting energy
-  double GetMulticastEnergy(std::uint64_t multicast_factor);
+  double GetMulticastEnergy(std::uint64_t multicast_factor, std::string data_space_name);
  
   EvalStatus Evaluate(const tiling::CompoundTile& tile,
                               const bool break_on_failure);

--- a/src/model/network-simple-multicast.hpp
+++ b/src/model/network-simple-multicast.hpp
@@ -55,7 +55,12 @@ class SimpleMulticastNetwork : public Network
 
     // Post-floorplanning physical attributes.
     Attribute<double> tile_width; // um
+
+    // For ERT parsing
     config::CompoundConfigNode accelergyERT;
+    std::string action_name;
+    std::string multicast_factor_argument;
+    bool per_datatype_ERT;
 
     const std::string Type() const override { return type; }
 
@@ -69,7 +74,9 @@ class SimpleMulticastNetwork : public Network
       if (version == 0)
       {
         ar& BOOST_SERIALIZATION_NVP(word_bits);
-        ar& BOOST_SERIALIZATION_NVP(tile_width);
+        ar& BOOST_SERIALIZATION_NVP(action_name);
+        ar& BOOST_SERIALIZATION_NVP(multicast_factor_argument);
+        ar& BOOST_SERIALIZATION_NVP(per_datatype_ERT);
       }
     }
 
@@ -161,7 +168,9 @@ class SimpleMulticastNetwork : public Network
   void SetTileWidth(double width_um);
 
   // Parse ERT to get multi-casting energy
-  double GetMulticastEnergy(std::uint64_t multicast_factor, std::string data_space_name);
+  double GetOpEnergyFromERT(std::uint64_t multicast_factor, std::string operation_name);
+  double GetMulticastEnergy(std::uint64_t multicast_factor);
+  double GetMulticastEnergyByDataType(std::uint64_t multicast_factor, std::string data_space_name);
  
   EvalStatus Evaluate(const tiling::CompoundTile& tile,
                               const bool break_on_failure);

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -81,9 +81,18 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
   table.getMapKeys(keys);
   for (auto key : keys) {
     auto componentERT = table.lookup(key);
-    auto pos = key.rfind(".");
-    auto componentName = key.substr(pos + 1, key.size() - pos - 1);
-    // std::cout << componentName << std::endl;
+    auto rangePos = key.rfind("..");
+    auto levelPos = key.rfind(".");
+    std::string componentName;
+    if (rangePos != std::string::npos && rangePos == levelPos - 1){
+       std::string subkey = key.substr(0, rangePos - 2);
+       levelPos = subkey.rfind(".");
+       componentName = subkey.substr(levelPos + 1, subkey.size() - levelPos - 1);
+       // std::cout << "component name: " << componentName << std::endl;
+    } else {
+       componentName = key.substr(levelPos + 1, key.size() - levelPos - 1);
+       // std::cout << "component name: " << componentName << std::endl;
+    }
 
     // update levels by name and the type of it
     if (componentName == "wire" || componentName == "Wire") { // special case, update interal wire model
@@ -111,7 +120,6 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
       bool isBuffer = false;
       std::shared_ptr<LevelSpecs> specToUpdate;
       for (auto level : levels) {
-        //std::cout << "  level: " << level->level_name << std::endl;
         if (level->level_name == componentName) {
           specToUpdate = level;
           if (level->Type() == "BufferLevel") isBuffer = true;

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -98,13 +98,13 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
       }
     } else {
       // Check if the ERT describes any network associated with a storage component
-      for (unsigned i = 0; i < NumStorageLevels(); i++) {
-          auto bufferSpec = GetStorageLevel(i);
+      for (unsigned i = 0; i < NumNetworks(); i++) {
+          // only check the user-defined networks
           auto networkSpec = GetNetwork(i);
           if (networkSpec->Type() == "SimpleMulticast" && networkSpec->name == componentName){
-           // std::cout << "simple multicast component identified: " << componentName << std::endl;
+            // std::cout << "simple multicast component identified: " << componentName << std::endl;
             std::static_pointer_cast<SimpleMulticastNetwork::Specs>(networkSpec)->accelergyERT = componentERT;
-          }
+           }
       }
       // Find the level that matches this name and see what type it is
       bool isArithmeticUnit = false;
@@ -145,7 +145,7 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
       } else if (isBuffer) {
         auto bufferSpec = std::static_pointer_cast<BufferLevel::Specs>(specToUpdate);
         // std::cout << "  Replace " << componentName << " VectorAccess energy with energy " << opEnergy << std::endl;
-        bufferSpec->vector_access_energy = opEnergy / bufferSpec->cluster_size.Get();
+        bufferSpec->vector_access_energy = opEnergy/bufferSpec->cluster_size.Get();
       } else {
         // std::cout << "  Unused component ERT: "  << key << std::endl;
       }
@@ -280,7 +280,7 @@ std::ostream& operator << (std::ostream& out, const Topology& topology)
   out << "Networks" << std::endl;
   out << "--------" << std::endl;
 
-#define PRINT_NETWORKS_IN_LEGACY_ORDER
+//#define PRINT_NETWORKS_IN_LEGACY_ORDER
 #ifdef PRINT_NETWORKS_IN_LEGACY_ORDER
   for (unsigned storage_level_id = 0; storage_level_id < topology.NumStorageLevels(); storage_level_id++)
   {


### PR DESCRIPTION
1) fix network ERT fetch bug by only looking at user-defined networks
2) previous ERT parsing does not perform correctly when lowest-level component names contain [A..B], fixed it
3) print all networks?