### PR TITLE
Fix #100 Added include of <numeric> for definition of std::accumulate.

### DIFF
--- a/src/loop-analysis/nest-analysis-tile-info.cpp
+++ b/src/loop-analysis/nest-analysis-tile-info.cpp
@@ -25,6 +25,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <numeric>
+
 #include "loop-analysis/nest-analysis-tile-info.hpp"
 
 namespace analysis


### PR DESCRIPTION
Fixes #100 Adds missing include of <numeric> header file for definition of std::accumulate.