### PR TITLE
fix for #119

### DIFF
--- a/include/model/arithmetic.hpp
+++ b/include/model/arithmetic.hpp
@@ -82,7 +82,7 @@ class ArithmeticUnits : public Level
 
    public:
 
-    void UpdateOpEnergyViaERT();
+    void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy) override;
 
     std::shared_ptr<LevelSpecs> Clone() const override
     {

--- a/include/model/arithmetic.hpp
+++ b/include/model/arithmetic.hpp
@@ -83,7 +83,8 @@ class ArithmeticUnits : public Level
    public:
 
     void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy) override;
-
+    void UpdateAreaViaART(const double component_area) override;
+    
     std::shared_ptr<LevelSpecs> Clone() const override
     {
       return std::static_pointer_cast<LevelSpecs>(std::make_shared<Specs>(*this));

--- a/include/model/buffer.hpp
+++ b/include/model/buffer.hpp
@@ -183,8 +183,8 @@ class BufferLevel : public Level
       return std::static_pointer_cast<LevelSpecs>(std::make_shared<Specs>(*this));
     }
 
-    void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy);
-
+    void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy) override;
+    void UpdateAreaViaART(const double component_area) override;
   };
   
   //

--- a/include/model/buffer.hpp
+++ b/include/model/buffer.hpp
@@ -183,7 +183,7 @@ class BufferLevel : public Level
       return std::static_pointer_cast<LevelSpecs>(std::make_shared<Specs>(*this));
     }
 
-    void UpdateOpEnergyViaERT();
+    void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy);
 
   };
   

--- a/include/model/level.hpp
+++ b/include/model/level.hpp
@@ -51,7 +51,8 @@ struct LevelSpecs
 
   virtual const std::string Type() const = 0;
   virtual void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy) = 0; 
-  
+  virtual void UpdateAreaViaART(const double component_area) = 0;  
+
   std::string level_name;
 
   // Serialization

--- a/include/model/level.hpp
+++ b/include/model/level.hpp
@@ -50,7 +50,8 @@ struct LevelSpecs
   virtual std::shared_ptr<LevelSpecs> Clone() const = 0;
 
   virtual const std::string Type() const = 0;
-
+  virtual void UpdateOpEnergyViaERT(const std::map<std::string, double>& ERT_entries, const double max_energy) = 0; 
+  
   std::string level_name;
 
   // Serialization

--- a/include/model/network-legacy.hpp
+++ b/include/model/network-legacy.hpp
@@ -66,6 +66,7 @@ class LegacyNetwork : public Network
     Attribute<bool> is_sparse_module;
     
     const std::string Type() const override { return type; }
+    bool SupportAccelergyTables() const override { return false; }
 
     // Serialization
     friend class boost::serialization::access;

--- a/include/model/network-legacy.hpp
+++ b/include/model/network-legacy.hpp
@@ -67,7 +67,8 @@ class LegacyNetwork : public Network
     
     const std::string Type() const override { return type; }
     bool SupportAccelergyTables() const override { return false; }
-
+    void ProcessERT(const config::CompoundConfigNode& ERT) override;
+    
     // Serialization
     friend class boost::serialization::access;
 

--- a/include/model/network-reduction-tree.hpp
+++ b/include/model/network-reduction-tree.hpp
@@ -62,7 +62,8 @@ class ReductionTreeNetwork : public Network
     
     const std::string Type() const override { return type; }
     bool SupportAccelergyTables() const override { return false; }
-
+    void ProcessERT(const config::CompoundConfigNode& ERT) override;
+    
     // Serialization
     friend class boost::serialization::access;
 

--- a/include/model/network-reduction-tree.hpp
+++ b/include/model/network-reduction-tree.hpp
@@ -61,6 +61,7 @@ class ReductionTreeNetwork : public Network
     Attribute<bool> is_sparse_module;
     
     const std::string Type() const override { return type; }
+    bool SupportAccelergyTables() const override { return false; }
 
     // Serialization
     friend class boost::serialization::access;

--- a/include/model/network-simple-multicast.hpp
+++ b/include/model/network-simple-multicast.hpp
@@ -65,7 +65,8 @@ class SimpleMulticastNetwork : public Network
     bool per_datatype_ERT;
 
     const std::string Type() const override { return type; }
-
+    bool SupportAccelergyTables() const override { return true; }
+    
     // Serialization
     friend class boost::serialization::access;
 

--- a/include/model/network-simple-multicast.hpp
+++ b/include/model/network-simple-multicast.hpp
@@ -66,6 +66,7 @@ class SimpleMulticastNetwork : public Network
 
     const std::string Type() const override { return type; }
     bool SupportAccelergyTables() const override { return true; }
+    void ProcessERT(const config::CompoundConfigNode& ERT) override;
     
     // Serialization
     friend class boost::serialization::access;

--- a/include/model/network.hpp
+++ b/include/model/network.hpp
@@ -55,6 +55,7 @@ struct NetworkSpecs
 
   virtual const std::string Type() const = 0;
   virtual bool SupportAccelergyTables() const = 0;
+  virtual void ProcessERT(const config::CompoundConfigNode& ERT) = 0;
   
   std::string name = "UNSET";
   ConnectionType cType = Unused;

--- a/include/model/network.hpp
+++ b/include/model/network.hpp
@@ -54,7 +54,8 @@ struct NetworkSpecs
   virtual std::shared_ptr<NetworkSpecs> Clone() const = 0;
 
   virtual const std::string Type() const = 0;
-
+  virtual bool SupportAccelergyTables() const = 0;
+  
   std::string name = "UNSET";
   ConnectionType cType = Unused;
 

--- a/include/model/topology.hpp
+++ b/include/model/topology.hpp
@@ -54,9 +54,9 @@ namespace model
 
 // format {timeloop_action_name: [priority list of ERT action names]}
 static std::map <std::string, std::vector<std::string>> arithmeticOperationMappings
-  = {{"random_compute", {"mac_random", "mult_random", "mac", "mult"}},
-     {"skipped_compute", {"mac_skipped", "mult_skipped", "mac_gated", "mult_gated", "mac", "mult"}},
-     {"gated_compute", {"mac_gated", "mult_gated", "mac", "mult"}}
+  = {{"random_compute", {"mac_random", "mult_random", "mac", "mult", "compute"}},
+     {"skipped_compute", {"mac_skipped", "mult_skipped","compute_skipped", "mac_gated", "mult_gated", "compute_gated", "mac", "mult", "compute"}},
+     {"gated_compute", {"mac_gated", "mult_gated", "compute_gated", "mac", "mult", "compute"}}
   };
 
 static std::map <std::string, std::vector<std::string>> storageOperationMappings

--- a/src/model/arithmetic.cpp
+++ b/src/model/arithmetic.cpp
@@ -46,8 +46,12 @@ ArithmeticUnits::ArithmeticUnits(const Specs& specs) :
   area_ = specs_.area.Get();
 }
 
-void ArithmeticUnits::Specs::UpdateOpEnergyViaERT()
+void ArithmeticUnits::Specs::UpdateOpEnergyViaERT(const std::map<std::string, double>& ert_entries, const double max_energy)
 {
+  
+  energy_per_op = max_energy;
+  ERT_entries = ert_entries;
+  
   for (unsigned op_id = 0; op_id < tiling::arithmeticOperationTypes.size(); op_id++)
   {
     // go through all op types

--- a/src/model/arithmetic.cpp
+++ b/src/model/arithmetic.cpp
@@ -71,6 +71,10 @@ void ArithmeticUnits::Specs::UpdateOpEnergyViaERT(const std::map<std::string, do
   }
 }
 
+void ArithmeticUnits::Specs::UpdateAreaViaART(const double component_area)
+{
+  area = component_area;   
+}
 
 ArithmeticUnits::Specs ArithmeticUnits::ParseSpecs(config::CompoundConfigNode setting, uint32_t nElements, bool is_sparse_module)
 {

--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -88,6 +88,12 @@ void BufferLevel::Specs::UpdateOpEnergyViaERT(const std::map<std::string, double
 }
 
 
+void BufferLevel::Specs::UpdateAreaViaART(double component_area)
+{
+  storage_area = component_area;
+}
+
+
 // The hierarchical ParseSpecs functions are static and do not
 // affect the internal specs_ data structure, which is set by
 // the dynamic Spec() call later.

--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -62,8 +62,12 @@ BufferLevel::BufferLevel(const Specs& specs) :
 BufferLevel::~BufferLevel()
 { }
 
-void BufferLevel::Specs::UpdateOpEnergyViaERT()
+void BufferLevel::Specs::UpdateOpEnergyViaERT(const std::map<std::string, double>& ert_entries, double max_energy)
 {
+  
+  vector_access_energy = max_energy/cluster_size.Get();
+  ERT_entries = ert_entries;
+
   for (unsigned op_id = 0; op_id < tiling::storageOperationTypes.size(); op_id++)
   {
     // go through all op types

--- a/src/model/network-legacy.cpp
+++ b/src/model/network-legacy.cpp
@@ -128,6 +128,12 @@ LegacyNetwork::Specs LegacyNetwork::ParseSpecs(config::CompoundConfigNode networ
   return specs;
 }
 
+void LegacyNetwork::Specs::ProcessERT(const config::CompoundConfigNode& ERT)
+{
+  (void) ERT;
+  assert(false);
+}
+
 void LegacyNetwork::ConnectSource(std::weak_ptr<Level> source)
 {
   source_ = source;

--- a/src/model/network-reduction-tree.cpp
+++ b/src/model/network-reduction-tree.cpp
@@ -105,6 +105,13 @@ ReductionTreeNetwork::Specs ReductionTreeNetwork::ParseSpecs(config::CompoundCon
   return specs;
 }
 
+void ReductionTreeNetwork::Specs::ProcessERT(const config::CompoundConfigNode& ERT)
+{
+  (void) ERT;
+  assert(false);
+}
+
+
 void ReductionTreeNetwork::ConnectSource(std::weak_ptr<Level> source)
 {
   source_ = source;

--- a/src/model/network-simple-multicast.cpp
+++ b/src/model/network-simple-multicast.cpp
@@ -120,6 +120,11 @@ SimpleMulticastNetwork::Specs SimpleMulticastNetwork::ParseSpecs(config::Compoun
   return specs;
 }
 
+void SimpleMulticastNetwork::Specs::ProcessERT(const config::CompoundConfigNode& ERT)
+{
+  accelergyERT = ERT; 
+}
+
 void SimpleMulticastNetwork::ConnectSource(std::weak_ptr<Level> source)
 {
   source_ = source;
@@ -165,6 +170,7 @@ void SimpleMulticastNetwork::SetTileWidth(double width_um)
     specs_.tile_width = width_um;
   }
 }
+
 
 double SimpleMulticastNetwork::GetOpEnergyFromERT(std::uint64_t multicast_factor, std::string operation_name){
     double opEnergy = 0.0;

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -194,12 +194,14 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
       for (unsigned i = 0; i < NumNetworks(); i++) {
           // only check the user-defined networks
           auto networkSpec = GetNetwork(i);
-          if (networkSpec->Type() == "SimpleMulticast" && networkSpec->name == componentName){
-            assert(false); // FIXME: why is the name of a network class exposed in this file?
-            //if (std::static_pointer_cast<SimpleMulticastNetwork::Specs>(networkSpec)){
-            //  // std::cout << "simple multicast component identified: " << componentName << std::endl;
-            //  std::static_pointer_cast<SimpleMulticastNetwork::Specs>(networkSpec)->accelergyERT = componentERT;
-            //}
+          if (networkSpec->SupportAccelergyTables() && networkSpec->name == componentName){
+            // assert(false); // FIXME: why is the name of a network class exposed in this file?
+            // Only simplemulticast network support ERT parsing,
+            // Instead using the exact name, added an interface function for the check
+            if (std::static_pointer_cast<SimpleMulticastNetwork::Specs>(networkSpec)){
+              // std::cout << "NoC that supports Acceleragy tables identified: " << componentName << std::endl;
+              std::static_pointer_cast<SimpleMulticastNetwork::Specs>(networkSpec)->accelergyERT = componentERT;
+            }
           }
       }
       // Find the level that matches this name and see what type it is

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -75,30 +75,25 @@ void Topology::Specs::ParseAccelergyART(config::CompoundConfigNode art)
     float componentArea;
     componentART.lookupValue("area", componentArea);
     
-    // Find the level that matches this name and see what type it is
-    bool isArithmeticUnit = false;
-    bool isBuffer = false;
+    // Find the level that matches this name
     std::shared_ptr<LevelSpecs> specToUpdate;
-    for (auto level : levels) {
-      if (level->level_name == componentName) {
+    for (auto level : levels)
+    {
+      if (level->level_name == componentName)
+      {
         specToUpdate = level;
-        if (level->Type() == "BufferLevel") isBuffer = true;
-        if (level->Type() == "ArithmeticUnits") isArithmeticUnit = true;
       }
     }
- 
-    // Replace the energy per action
-    if (isArithmeticUnit) {
-      //std::cout << "  Replace " << componentName << " area with area " << componentArea << std::endl;
-      auto arithmeticSpec = GetArithmeticLevel();
-      arithmeticSpec->area = componentArea;
-    } else if (isBuffer) {
-      auto bufferSpec = std::static_pointer_cast<BufferLevel::Specs>(specToUpdate);
-      //std::cout << "  Replace " << componentName << " cluster area with area " << componentArea << std::endl;
-      bufferSpec->storage_area = componentArea/bufferSpec->cluster_size.Get();
-    } else {
+    
+    // Populate area  
+    if (specToUpdate)
+    {
+      specToUpdate->UpdateAreaViaART(componentArea);
+    }
+    else
+    {
       //std::cout << "  Unused component ART: "  << hierachicalName << std::endl;
-    } 
+    }
   }
 }
 
@@ -201,7 +196,7 @@ void Topology::Specs::ParseAccelergyERT(config::CompoundConfigNode ert)
           networkSpec->ProcessERT(componentERT);
         }
       }
-      // Find the level that matches this name and see what type it is
+      // Find the level that matches this name
       std::shared_ptr<LevelSpecs> specToUpdate;
       for (auto level : levels) 
       {


### PR DESCRIPTION
Summary of changes
1. There was an assert false since the NoC class name is exposed. This broke the example. Added an interface function call for NoC classes to avoid exposing the class name.
2. Add `compute` as an action name for arithmetic components, addressing the specific problem in the issue.