### PR TITLE
Add print stats for operational intensity, GFLOPs, and EDP

### DIFF
--- a/include/loop-analysis/tiling.hpp
+++ b/include/loop-analysis/tiling.hpp
@@ -40,6 +40,7 @@
 
 namespace tiling
 {
+extern bool gEnableFirstReadElision;
 
 bool operator < (const DataMovementInfo& a, const DataMovementInfo& b);
 std::ostream& operator << (std::ostream& out, const DataMovementInfo& info);

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -460,7 +460,7 @@ for (unsigned i = 0; i < topology.NumStorageLevels(); i++)
   std::shared_ptr<BufferLevel> buffer_level = topology.GetStorageLevel(i);
   auto stats = buffer_level->GetStats();
   out << "=== " << buffer_level->Name() << " ===" << std::endl;
-
+  uint64_t instances = buffer_level->GetSpecs().instances.Get();
   uint64_t total_scalar_access = 0;
   for (unsigned pvi = 0; pvi < unsigned(problem::GetShape()->NumDataSpaces); pvi++)
   {
@@ -476,7 +476,7 @@ for (unsigned i = 0; i < topology.NumStorageLevels(); i++)
         if (stats.fine_grained_scalar_accesses.at(pv).find(key) != stats.fine_grained_scalar_accesses.at(pv).end())
         {
           uint64_t scalar_access = stats.fine_grained_scalar_accesses.at(pv).at(key);
-          total_scalar_access += scalar_access;
+          total_scalar_access += scalar_access * instances;
           // std::string access_type_str = "Actual scalar " + access_type + "s (per-instance)"; 
           // out << indent + indent << std::left << std::setw(66) << access_type_str;                         
           // out << ": " << scalar_access << std::endl << std::endl;
@@ -488,7 +488,7 @@ for (unsigned i = 0; i < topology.NumStorageLevels(); i++)
   float op_per_byte = -1;
   if (total_scalar_access > 0)
   {
-    out << indent << std::left << std::setw(70) << "Total scalar accesses (per-instance)";
+    out << indent << std::left << std::setw(70) << "Total scalar accesses";
     out << ": " << total_scalar_access << std::endl;
     op_per_byte = float(total_ops) / (buffer_level->GetSpecs().word_bits.Get() * total_scalar_access / 8);
     out << indent << std::left << std::setw(70) << "Op per Byte";


### PR DESCRIPTION
Add print stats for operational intensity. 
Example stats look like this:
```
Operational Intensity Stats
---------------------------
    Total memory accesses required                                        : 4160
    Optimal MAC per 1 B memory access                                     : 11.82
    Optimal Op per Byte                                                   : 23.63

=== RegisterFile ===
    Total scalar accesses (per-instance)                                  : 14624
    MAC per 1 B memory access                                             : 3.36
    Op per Byte                                                           : 6.72
=== GlobalBuffer ===
    Total scalar accesses (per-instance)                                  : 40640
    MAC per 1 B memory access                                             : 1.21
    Op per Byte                                                           : 2.42
=== MainMemory ===
    Total scalar accesses (per-instance)                                  : 4160
    MAC per 1 B memory access                                             : 11.82
    Op per Byte                                                           : 23.63
```

Also added summary stats for GFLOPs and EDP: 
```
Summary Stats
-------------
GFLOPs (@1GHz): 32.00
Utilization: 1.00
Cycles: 3072
Energy: 0.52 uJ
EDP(J*cycle): 1.59e-03
Area: 0.70 mm^2

```
