### PR TITLE
Added options for scientific or default floating point outputs

### DIFF
--- a/include/model/util.hpp
+++ b/include/model/util.hpp
@@ -26,6 +26,7 @@
  */
 
 #pragma once
+#include <iostream>
 
 namespace model
 {
@@ -63,7 +64,16 @@ Type FuncName(problem::Shape::DataSpaceID pv = problem::GetShape()->NumDataSpace
   STAT_ACCESSOR_HEADER(Type, FuncName)                                                \
   STAT_ACCESSOR_BODY(Type, FuncName, Expression)
 
+extern bool enableScientificStatOutput;
+extern bool enableDefaultFloatStatOutput;
+
+
 #define PRINTFLOAT_PRECISION std::setprecision(3)
 #define LOG_FLOAT_PRECISION std::setprecision(2)
+
+#define OUT_FLOAT_FORMAT (                                                          \
+  model::enableScientificStatOutput ? std::scientific :                             \
+  model::enableDefaultFloatStatOutput ? std::defaultfloat : std::fixed              \
+)
 
 } // namespace model

--- a/src/SConscript
+++ b/src/SConscript
@@ -142,6 +142,7 @@ model/network-reduction-tree.cpp
 model/network-simple-multicast.cpp
 model/sparse-optimization-info.cpp
 model/sparse-optimization-parser.cpp
+model/util.cpp
 util/banner.cpp
 util/args.cpp
 util/numeric.cpp

--- a/src/applications/design-space/design-space.cpp
+++ b/src/applications/design-space/design-space.cpp
@@ -47,8 +47,8 @@ void PointResult::PrintEvaluationResult(std::ostream& out)
 {
   out << config_name_ ; 
   out << ", " << result_.stats.algorithmic_computes;
-  out << ", " << std::setw(4) << std::fixed << std::setprecision(2) << result_.stats.utilization;
-  out << ", " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << result_.stats.energy / result_.stats.algorithmic_computes << std::endl;
+  out << ", " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << result_.stats.utilization;
+  out << ", " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << result_.stats.energy / result_.stats.algorithmic_computes << std::endl;
 }
 
 //--------------------------------------------//

--- a/src/applications/mapper/mapper-thread.cpp
+++ b/src/applications/mapper/mapper-thread.cpp
@@ -302,8 +302,8 @@ void MapperThread::Run()
 
       if (valid_mappings > 0)
       {
-        msg << std::setw(10) << std::fixed << std::setprecision(2) << (stats_.thread_best.stats.utilization * 100) << "%"
-            << std::setw(11) << std::fixed << PRINTFLOAT_PRECISION << stats_.thread_best.stats.energy /
+        msg << std::setw(10) << OUT_FLOAT_FORMAT << std::setprecision(2) << (stats_.thread_best.stats.utilization * 100) << "%"
+            << std::setw(11) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats_.thread_best.stats.energy /
           stats_.thread_best.stats.algorithmic_computes;
       }
 
@@ -536,17 +536,17 @@ void MapperThread::Run()
       if (is_sparse_topology)
       {      
         log_stream_ << "[" << std::setw(3) << thread_id_ << "]" 
-                  << " Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << stats.utilization 
-                  << " | pJ/Algorithmic-Compute = " << std::setw(4) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.algorithmic_computes
-                  << " | pJ/Compute = " << std::setw(4) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
+                  << " Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << stats.utilization 
+                  << " | pJ/Algorithmic-Compute = " << std::setw(4) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.algorithmic_computes
+                  << " | pJ/Compute = " << std::setw(4) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
                   << " | " << mapping.PrintCompact()
                   << std::endl;
       }
       else
       {
         log_stream_ << "[" << std::setw(3) << thread_id_ << "]" 
-                  << " Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << stats.utilization 
-                  << " | pJ/Compute = " << std::setw(4) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
+                  << " Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << stats.utilization 
+                  << " | pJ/Compute = " << std::setw(4) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
                   << " | " << mapping.PrintCompact()
                   << std::endl;
       }
@@ -574,17 +574,17 @@ void MapperThread::Run()
         if (is_sparse_topology)
         {      
           log_stream_ << "[" << std::setw(3) << thread_id_ << "]" 
-                    << " Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << stats.utilization 
-                    << " | pJ/Algorithmic-Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.algorithmic_computes
-                    << " | pJ/Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
+                    << " Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << stats.utilization 
+                    << " | pJ/Algorithmic-Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.algorithmic_computes
+                    << " | pJ/Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
                     << " | " << mapping.PrintCompact()
                     << std::endl;
         }
         else
         {
           log_stream_ << "[" << std::setw(3) << thread_id_ << "]" 
-                    << " Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << stats.utilization 
-                    << " | pJ/Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
+                    << " Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << stats.utilization 
+                    << " | pJ/Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << stats.energy / stats.actual_computes
                     << " | " << mapping.PrintCompact()
                     << std::endl;
         }        mutex_->unlock();

--- a/src/applications/mapper/mapper.cpp
+++ b/src/applications/mapper/mapper.cpp
@@ -529,21 +529,21 @@ void Application::Run()
     if (!sparse_optimizations_->no_optimization_applied)
     {
       std::cout << "Summary stats for best mapping found by mapper:" << std::endl;
-      std::cout << "  Utilization = " << std::setw(4) << std::fixed << std::setprecision(2)
+      std::cout << "  Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2)
                 << global_best_.stats.utilization << " | pJ/Algorithmic-Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << global_best_.stats.energy /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << global_best_.stats.energy /
         global_best_.stats.algorithmic_computes
                 << " | pJ/Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << global_best_.stats.energy /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << global_best_.stats.energy /
         global_best_.stats.actual_computes << std::endl;
     }
     else
     {
       std::cout << "Summary stats for best mapping found by mapper:" << std::endl;
-      std::cout << "  Utilization = " << std::setw(4) << std::fixed << std::setprecision(2)
+      std::cout << "  Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2)
                 << global_best_.stats.utilization
                 << " | pJ/Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << global_best_.stats.energy /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << global_best_.stats.energy /
         global_best_.stats.actual_computes << std::endl;
     }
     

--- a/src/applications/model/model.cpp
+++ b/src/applications/model/model.cpp
@@ -247,16 +247,16 @@ Application::Stats Application::Run()
   {
     if (!sparse_optimizations_->no_optimization_applied)
     {   
-      std::cout << "Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << engine.Utilization()
-              << " | pJ/Algorithmic-Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << engine.Energy() /
+      std::cout << "Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << engine.Utilization()
+              << " | pJ/Algorithmic-Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << engine.Energy() /
       engine.GetTopology().AlgorithmicComputes()
-              << " | pJ/Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << engine.Energy() /
+              << " | pJ/Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << engine.Energy() /
       engine.GetTopology().ActualComputes() << std::endl;
     }
     else
     {
-      std::cout << "Utilization = " << std::setw(4) << std::fixed << std::setprecision(2) << engine.Utilization()
-                 << " | pJ/Compute = " << std::setw(8) << std::fixed << PRINTFLOAT_PRECISION << engine.Energy() /
+      std::cout << "Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2) << engine.Utilization()
+                 << " | pJ/Compute = " << std::setw(8) << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << engine.Energy() /
       engine.GetTopology().ActualComputes() << std::endl;
     }
     std::ofstream map_txt_file(map_txt_file_name);

--- a/src/applications/simple-mapper/simple-mapper.cpp
+++ b/src/applications/simple-mapper/simple-mapper.cpp
@@ -198,20 +198,20 @@ void Application::Run()
     if (!sparse_optimizations_->no_optimization_applied)
     {
       std::cout << "Summary stats for best mapping found by mapper:" << std::endl;
-      std::cout << "  Utilization = " << std::setw(4) << std::fixed << std::setprecision(2)
+      std::cout << "  Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2)
                 << best_engine.Utilization() << " | pJ/Algorithmic-Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << best_engine.Energy() /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << best_engine.Energy() /
         best_engine.GetTopology().AlgorithmicComputes() << " | pJ/Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << best_engine.Energy() /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << best_engine.Energy() /
         best_engine.GetTopology().ActualComputes() << std::endl;
     }
     else
     {
       std::cout << "Summary stats for best mapping found by mapper:" << std::endl;
-      std::cout << "  Utilization = " << std::setw(4) << std::fixed << std::setprecision(2)
-                << std::fixed << PRINTFLOAT_PRECISION << best_engine.Energy() /
+      std::cout << "  Utilization = " << std::setw(4) << OUT_FLOAT_FORMAT << std::setprecision(2)
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << best_engine.Energy() /
         best_engine.GetTopology().AlgorithmicComputes() << " | pJ/Compute = " << std::setw(8)
-                << std::fixed << PRINTFLOAT_PRECISION << best_engine.Energy() /
+                << OUT_FLOAT_FORMAT << PRINTFLOAT_PRECISION << best_engine.Energy() /
         best_engine.GetTopology().ActualComputes() << std::endl;
     }
   }

--- a/src/model/topology.cpp
+++ b/src/model/topology.cpp
@@ -349,7 +349,7 @@ std::ostream& operator << (std::ostream& out, const Topology& topology)
   // Save ios format state.
   std::ios state(NULL);
   state.copyfmt(out);
-  out << std::fixed << LOG_FLOAT_PRECISION;
+  out << OUT_FLOAT_FORMAT << LOG_FLOAT_PRECISION;
 
   //
   // Detailed specs and stats.
@@ -512,7 +512,7 @@ out << std::endl
     out << "Utilization: " << topology.stats_.utilization << std::endl;
     out << "Cycles: " << topology.stats_.cycles << std::endl;
     out << "Energy: " << topology.stats_.energy / 1000000 << " uJ" << std::endl;
-    out << "EDP(J*cycle): " << std::scientific << float(topology.stats_.cycles) * topology.stats_.energy / 1e12 << std::fixed << std::endl;
+    out << "EDP(J*cycle): " << std::scientific << float(topology.stats_.cycles) * topology.stats_.energy / 1e12 << OUT_FLOAT_FORMAT << std::endl;
 
   }
   out << "Area: " << topology.stats_.area / 1000000 << " mm^2" << std::endl;

--- a/src/model/util.cpp
+++ b/src/model/util.cpp
@@ -1,0 +1,45 @@
+/* Copyright (c) 2019, NVIDIA CORPORATION. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  * Neither the name of NVIDIA CORPORATION nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "model/util.hpp"
+#include <string.h>
+
+// If both are false, fixed point is used
+bool gEnableScientificStatOutput = 
+    (getenv("TIMELOOP_OUTPUT_STAT_SCIENTIFIC") != NULL) &&
+    (strcmp(getenv("TIMELOOP_OUTPUT_STAT_SCIENTIFIC"), "0") != 0);
+bool gEnableDefaultFloatStatOutput = 
+    (getenv("TIMELOOP_OUTPUT_STAT_DEFAULT_FLOAT") != NULL) &&
+    (strcmp(getenv("TIMELOOP_OUTPUT_STAT_DEFAULT_FLOAT"), "0") != 0);
+
+namespace model
+{
+
+  bool enableScientificStatOutput = gEnableScientificStatOutput;
+  bool enableDefaultFloatStatOutput = gEnableDefaultFloatStatOutput;
+
+} // namespace model


### PR DESCRIPTION
Enable scientific notation output with environment variable TIMELOOP_OUTPUT_STAT_SCIENTIFIC=1
Enable default floating point output with TIMELOOP_OUTPUT_STAT_DEFAULT_FLOAT=1
