### PR TITLE
don't override vector access energy from ERT if user specified

### DIFF
--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -64,6 +64,10 @@ BufferLevel::~BufferLevel()
 
 void BufferLevel::Specs::UpdateOpEnergyViaERT(const std::map<std::string, double>& ert_entries, double max_energy)
 {
+  // don't override user-specific vector access energy
+  if (vector_access_energy.IsSpecified()) {
+    return;
+  }
   
   vector_access_energy = max_energy/cluster_size.Get();
   ERT_entries = ert_entries;


### PR DESCRIPTION
If using Accelergy, `vector-access-energy` specified in arch YAML is overridden by `src/model/buffer.cpp:UpdateOpEnergyViaERT()`. I used `Attribute<double> vector_access_energy` from `buffer.hpp` to check whether this value is specified.