### PR TITLE
fix check for user specified vector-access-energy

### DIFF
--- a/include/model/buffer.hpp
+++ b/include/model/buffer.hpp
@@ -145,9 +145,11 @@ class BufferLevel : public Level
     // Physical Attributes (derived from technology model).
     // FIXME: move into separate struct?
     Attribute<double> vector_access_energy; // pJ
-    bool vector_access_energy_user_specified;
     Attribute<double> storage_area; // um^2
     Attribute<double> addr_gen_energy; // pJ
+    std::string access_energy_source;
+    std::string addr_gen_energy_source;
+    std::string storage_area_source;
 
     Attribute<bool> is_sparse_module;
     

--- a/include/model/buffer.hpp
+++ b/include/model/buffer.hpp
@@ -145,6 +145,7 @@ class BufferLevel : public Level
     // Physical Attributes (derived from technology model).
     // FIXME: move into separate struct?
     Attribute<double> vector_access_energy; // pJ
+    bool vector_access_energy_user_specified;
     Attribute<double> storage_area; // um^2
     Attribute<double> addr_gen_energy; // pJ
 

--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -65,7 +65,7 @@ BufferLevel::~BufferLevel()
 void BufferLevel::Specs::UpdateOpEnergyViaERT(const std::map<std::string, double>& ert_entries, double max_energy)
 {
   // don't override user-specific vector access energy
-  if (vector_access_energy.IsSpecified()) {
+  if (vector_access_energy_user_specified) {
     return;
   }
   
@@ -550,7 +550,9 @@ BufferLevel::Specs BufferLevel::ParseSpecs(config::CompoundConfigNode level, std
   }
 
   // Allow user to override the access energy.
-  buffer.lookupValue("vector-access-energy", tmp_access_energy);
+  // Also store that the vector access energy is from the user rather than the PAT;
+  // this will be referenced in UpdateOpEnergyViaERT() above.
+  specs.vector_access_energy_user_specified = buffer.lookupValue("vector-access-energy", tmp_access_energy);
 
   // Allow user to override the addr gen energy.
   double tmp_addr_gen_energy = -0.1;


### PR DESCRIPTION
add `bool vector_access_energy_user_specified` that tracks whether vector_access_energy originates from the user YAML or the PAT.