### PR TITLE
Add assertion to make sure the number of buffer instances is a multiple of cluster size

### DIFF
--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -324,7 +324,7 @@ BufferLevel::Specs BufferLevel::ParseSpecs(config::CompoundConfigNode level, std
   {
     assert(buffer.exists("sizeKB") == false);
     assert(buffer.exists("entries") == false);
-    specs.size = size * specs.block_size.Get();
+    specs.size = size * specs.block_size.Get() * specs.cluster_size.Get();
   }
   else if (buffer.lookupValue("sizeKB", size))
   {

--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -324,7 +324,7 @@ BufferLevel::Specs BufferLevel::ParseSpecs(config::CompoundConfigNode level, std
   {
     assert(buffer.exists("sizeKB") == false);
     assert(buffer.exists("entries") == false);
-    specs.size = size * specs.block_size.Get() * specs.cluster_size.Get();
+    specs.size = size * specs.block_size.Get();
   }
   else if (buffer.lookupValue("sizeKB", size))
   {
@@ -1269,9 +1269,11 @@ EvalStatus BufferLevel::ComputeScalarAccesses(const tiling::CompoundDataMovement
   }
 
   assert (specs_.block_size.IsSpecified());
-    
+
   assert (specs_.cluster_size.IsSpecified());
-   
+
+  assert ((specs_.instances.Get() % specs_.cluster_size.Get()) == 0);
+
   // Compute address-generation bits.
   if (specs_.size.IsSpecified())
   {


### PR DESCRIPTION
~~The buffer size calculation seems problematic when either `block-size` or `cluster-size` is specified and `cluster-size` is not equal to 1.~~

Given the following buffer specs: 
```
          width: 8192 
          depth: 128 
          word-bits: 8
```

1. Without specifying the  `block-size` or `cluster-size` in the buffer specs, the buffer size calculation is correct.  The following code infers `block-size=8192/8=1024` and `cluster-size=1`:
https://github.com/NVlabs/timeloop/blob/7d295e5c07db31540cfed79beec831f6ded41c66/src/model/buffer.cpp#L305 

2. With `block-size` specified to 32, the inferred `cluster-size=32`. 
https://github.com/NVlabs/timeloop/blob/7d295e5c07db31540cfed79beec831f6ded41c66/src/model/buffer.cpp#L301 
With `cluster-size` specified to 32 the inferred `block-size=32`
https://github.com/NVlabs/timeloop/blob/7d295e5c07db31540cfed79beec831f6ded41c66/src/model/buffer.cpp#L297.

However, the buffer size `specs.size` calculation only uses `block-size x depth` as shown https://github.com/NVlabs/timeloop/blob/7d295e5c07db31540cfed79beec831f6ded41c66/src/model/buffer.cpp#L327

~~The size we get from case 2 will always be missing the `cluster-size` factor when it is not equal to 1.~~ 
Not including the `cluster-size` in the calculation of buffer entries is actually the intended behavior. The number of entries should be equal to `block-size x depth`. 
 
![image (1)](https://user-images.githubusercontent.com/8976465/204488710-781401da-b5da-48b0-a191-e9f072e153d6.png)
