### PR TITLE
Workload propagation

### DIFF
--- a/include/mapping/parser.hpp
+++ b/include/mapping/parser.hpp
@@ -36,6 +36,6 @@ namespace mapping
 
 Mapping ParseAndConstruct(config::CompoundConfigNode config,
                           model::Engine::Specs& arch_specs,
-                          problem::Workload& workload);
+                          const problem::Workload& workload);
 
 } // namespace mapping

--- a/src/SConscript
+++ b/src/SConscript
@@ -62,12 +62,12 @@ if str(Platform()) != 'darwin':
 
 # barvinok needs to be before isl because it references isl functions
 if GetOption('with_isl'):
-    env.Append(LIBS = ['barvinok', 'isl', 'ntl', 'pthread', 'polylibgmp'])
+    env.Append(LIBS = ['barvinok', 'isl', 'ntl', 'pthread', 'polylibgmp', 'gmp'])
 
 if GetOption('link_static'):
     print("Using static linking.")
     env.Append(LINKFLAGS = [ '-Wl,--whole-archive', '-static', '-lpthread', '-Wl,--no-whole-archive'])
-    env.Append(LIBS = ['tinfo', 'gmp'])
+    env.Append(LIBS = ['tinfo', 'gpm'])
 else:
     print("Using dynamic linking.")
 


### PR DESCRIPTION
- Catch up with master
- Missing `const` in `ParseAndConstruct` bug. The `const` went missing somehow for a reason I couldn't figure out.