### PR TITLE
New arch spec changes

### DIFF
--- a/include/loop-analysis/nest-analysis-tile-info.hpp
+++ b/include/loop-analysis/nest-analysis-tile-info.hpp
@@ -123,7 +123,9 @@ struct DataMovementInfo
   std::uint64_t distributed_fanout;      // max range of fanout if distributed multicast is used.
   bool is_on_storage_boundary;
   bool is_master_spatial;
-  
+  bool rmw_on_first_writeback;
+  bool passthrough;
+
   void Reset();
 
   void Validate();

--- a/include/loop-analysis/nest-analysis.hpp
+++ b/include/loop-analysis/nest-analysis.hpp
@@ -128,6 +128,8 @@ class NestAnalysis
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough_;
 
   // Other state.
 

--- a/include/loop-analysis/tiling-tile-info.hpp
+++ b/include/loop-analysis/tiling-tile-info.hpp
@@ -111,6 +111,8 @@ struct DataMovementInfo
   std::uint64_t distributed_fanout;      // max range of fanout if distributed multicast is used.
   bool is_on_storage_boundary;
   bool is_master_spatial;
+  bool rmw_on_first_writeback;
+  bool passthrough;
   //double partition_fraction;
   std::size_t partition_fraction_denominator;
   // Tile density
@@ -181,6 +183,8 @@ struct DataMovementInfo
     coord_space_info.Clear();
     tile_density = NULL;
     expected_density = 0;
+    rmw_on_first_writeback = false;
+    passthrough = false;
   }
 
   void Validate()

--- a/include/mapping/constraints.hpp
+++ b/include/mapping/constraints.hpp
@@ -64,6 +64,8 @@ class Constraints
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough_;
 
  public:
   Constraints() = delete;
@@ -84,6 +86,8 @@ class Constraints
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> NoLinkTransfers() const;
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> NoMulticast() const;
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> NoTemporalReuse() const;
+  const std::unordered_map<unsigned, problem::PerDataSpace<bool>> RMWOnFirstWriteback() const;
+  const std::unordered_map<unsigned, problem::PerDataSpace<bool>> Passthrough() const;
 
   // Create a constraints object from a given mapping object. The resultant
   // constraints will *only* be satisfied by that mapping.

--- a/include/mapping/nest.hpp
+++ b/include/mapping/nest.hpp
@@ -98,6 +98,8 @@ class Nest
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough;
 
  public:
   Nest();

--- a/include/model/topology.hpp
+++ b/include/model/topology.hpp
@@ -61,24 +61,28 @@ static std::map <std::string, std::vector<std::string>> arithmeticOperationMappi
   };
 
 static std::map <std::string, std::vector<std::string>> storageOperationMappings
-  = {{"random_read", {"random_read", "read"}},
-     {"random_fill", {"random_fill", "write"}},
-     {"random_update", {"random_update", "random_fill", "write"}},
+  = {
+     {"random_read", {"random_read", "read"}},
      {"gated_read", {"gated_read", "idle", "read"}},
-     {"gated_fill", {"gated_fill", "gated_write", "gated_write", "idle", "write"}},
-     {"gated_update", {"gated_update", "gated_write", "gated_write", "idle", "write"}},
      {"skipped_read", {"skipped_read", "gated_read", "idle", "read"}},
-     {"skipped_fill", {"skipped_fill", "skipped_write", "gated_write", "idle", "write"}},
-     {"skipped_update", {"skipped_update", "skipped_write", "gated_write", "idle", "write"}},
-     {"random_metadata_read", {"random_metadata_read", "metadata_read", "metadata_idle", "idle"}},
+     {"random_metadata_read", {"random_metadata_read", "metadata_read"}},
      {"gated_metadata_read", {"gated_metadata_read", "metadata_idle", "metadata_read"}},
-     {"skipped_metadata_read", {"skipped_metadata_read", "metadata_idle", "metadata_read"}},
-     {"random_metadata_fill", {"random_metadata_fill", "metadata_write", "metadata_idle", "idle"}},
-     {"gated_metadata_fill", {"gated_metadata_fill", "gated_metadata_write", "metadata_idle", "metadata_write"}},
-     {"skipped_metadata_fill", {"skipped_metadata_fill", "skipped_metadata_write", "metadata_idle", "metadata_write"}},
-     {"random_metadata_update", {"random_metadata_update", "metadata_write", "metadata_idle", "idle"}},
-     {"gated_metadata_update", {"gated_metadata_update", "gated_metadata_write", "metadata_idle", "metadata_write"}},
-     {"skipped_metadata_update", {"skipped_metadata_update", "skipped_metadata_write", "metadata_idle", "metadata_write"}},
+     {"skipped_metadata_read", {"skipped_metadata_read", "gated_metadata_read", "metadata_idle", "metadata_read"}},
+
+     {"random_fill", {"random_fill", "random_write", "fill", "write"}},
+     {"gated_fill", {"gated_fill", "gated_write", "idle", "fill", "write"}},
+     {"skipped_fill", {"skipped_fill", "skipped_write", "gated_fill", "gated_write", "idle", "fill", "write"}},
+     {"random_metadata_fill", {"random_metadata_fill", "random_metadata_write", "metadata_fill", "metadata_write"}},
+     {"gated_metadata_fill", {"gated_metadata_fill", "gated_metadata_write", "metadata_idle", "metadata_fill", "metadata_write"}},
+     {"skipped_metadata_fill", {"skipped_metadata_fill", "skipped_metadata_write", "gated_metadata_fill", "gated_metadata_write", "metadata_idle", "metadata_fill", "metadata_write"}},
+
+     {"random_update", {"random_update", "random_write", "update", "write"}},
+     {"gated_update", {"gated_update", "gated_write", "idle", "update", "write"}},
+     {"skipped_update", {"skipped_update", "skipped_write", "gated_update", "gated_write", "idle", "update", "write"}},
+     {"random_metadata_update", {"random_metadata_update", "random_metadata_write", "metadata_update", "metadata_write"}},
+     {"gated_metadata_update", {"gated_metadata_update", "gated_metadata_write", "metadata_idle", "metadata_update", "metadata_write"}},
+     {"skipped_metadata_update", {"skipped_metadata_update", "skipped_metadata_write", "gated_metadata_update", "gated_metadata_write", "metadata_idle", "metadata_update", "metadata_write"}},
+
      {"decompression_count", {"decompression_count"}},
      {"compression_count", {"compression_count"}}
   };

--- a/src/mapping/constraints.cpp
+++ b/src/mapping/constraints.cpp
@@ -812,7 +812,7 @@ void Constraints::ParseSingleConstraint(
     assert(constraint.lookupValue("proportion", max_overbooked_proportion));
     confidence_thresholds_[level_id] =  1 - max_overbooked_proportion;
   }
-  else if (type == "datatype" || type == "bypass" || type == "bypassing")
+  else if (type == "datatype" || type == "bypass" || type == "bypassing" || type == "dataspace")
   {
     // Error handling for re-spec conflicts are inside the parse function.
     ParseDatatypeBypassSettings(attributes, arch_props_.TilingToStorage(level_id));

--- a/src/mapping/parser.cpp
+++ b/src/mapping/parser.cpp
@@ -259,7 +259,7 @@ Mapping ParseAndConstruct(config::CompoundConfigNode config,
         }
       }
     }
-    else if (type == "datatype" || type == "bypass")
+    else if (type == "datatype" || type == "bypass" || type == "dataspace")
     {
       auto level_id = FindTargetTilingLevel(directive, type);
       ParseUserDatatypeBypassSettings(directive,

--- a/src/mapspaces/ruby.cpp
+++ b/src/mapspaces/ruby.cpp
@@ -612,6 +612,8 @@ std::vector<Status> Ruby::ConstructMapping(
   mapping->loop_nest.no_link_transfer = constraints_.NoLinkTransfers();
   mapping->loop_nest.no_multicast = constraints_.NoMulticast();
   mapping->loop_nest.no_temporal_reuse = constraints_.NoTemporalReuse();
+  mapping->loop_nest.rmw_on_first_writeback = constraints_.RMWOnFirstWriteback();
+  mapping->loop_nest.passthrough = constraints_.Passthrough();
 
   return status;
 }

--- a/src/mapspaces/uber.cpp
+++ b/src/mapspaces/uber.cpp
@@ -596,6 +596,8 @@ std::vector<Status> Uber::ConstructMapping(
   mapping->loop_nest.no_link_transfer = constraints_.NoLinkTransfers();
   mapping->loop_nest.no_multicast = constraints_.NoMulticast();
   mapping->loop_nest.no_temporal_reuse = constraints_.NoTemporalReuse();
+  mapping->loop_nest.rmw_on_first_writeback = constraints_.RMWOnFirstWriteback();
+  mapping->loop_nest.passthrough = constraints_.Passthrough();
 
   return status;
 }


### PR DESCRIPTION
## Added rmw_on_first_writeback and passthrough settings for buffers
Problem addressed: Commit 450d44e changed the behavior of buffers, breaking architecture models that used the previous settings. 
Solution: Give fine-graned control of the access pattern for each buffer. "rmw_on_first_writeback" implements the same behavior as the gEnableFirstReadElision environment variable, but can affect each buffer / datatype individually. The idea behind the naming is that:
- By default, when we first write a buffer, we fill it with our first computed result. For all following (the 2nd through Nth) computations, we read, modify, and write the value back to the buffer.
- With rmw_on_first_writeback on, the buffer will be pre-filled with zero. Then, ALL computations incur a read-modify-writeback, including the first computed result.

"passthrough" allows buffers to pass data through to charge energy & throughput without affecting mapping. Uses include data converters, quantization, data landing zones.

## Dataspace synonym for bypass constraints
For consistent naming with the problem & sparse optimizations. Allow more flexibility with integrating more dataspace-oriented constraints in the future (rather than just "bypass")



## Below: Comment copied from the "organized storage operation mappings." commit
Problem addressed: In the previous version, there was no fixed precedence to choosing synonyms. A few examples: metadata updates can turn into idles, but not gated metadata updates. Random fills are random updates, but not vice versa. Gated write can take the place of skipped update, but gated update can not. This inconsistency makes it difficult to create components.

Precedence is now consistent. We have:
- An update is an update, a read is a read, and a fill is a fill.
- Gated_X, random_X, , skipped_X, metadata_X all correspond to their action names.

When an action cannot be found, synonyms are followed in the following order of precedence until a valid mapping is found:
- fill -> write
- update -> write
- tandom_X -> X
- gated_X -> idle iff X is not a metadata action, else gated_X -> idle_X
- gated_X -> X
- skipped_X -> gated_X
- skipped_X -> idle idle iff X is not a metadata action, else skipped_X-> idle_X
- skipped_X -> X
    
The pattern is easily seen in "skipped_fill": "skipped_fill", {"skipped_fill", "skipped_write", "gated_fill", "gated_write", "idle", "fill", "write"}. First "skipped_fill" is tried, followed by "skipped_write". When those don't work, gated fill and write are tried. When those don't work, idle is tried, followed by fill and write.

With this new system, we now have an organized way to represent all mappings. Users can specify different sets of actions depending on what they are interested in:
- User only cares about reads/writes: specify reads/writes
- User would like to distinguish between fills and updates: specify read/fill/update
- User would like to specify sparse actions: add gated_ skipped_ random_ prefixes to actions


