### PR TITLE
Orders-of-magnitude faster Ruby

### DIFF
--- a/include/applications/mapper/mapper-thread.hpp
+++ b/include/applications/mapper/mapper-thread.hpp
@@ -94,6 +94,7 @@ class MapperThread
   uint128_t search_size_;
   std::uint32_t timeout_;
   std::uint32_t victory_condition_;
+  std::int32_t max_temporal_loops_in_a_mapping_;
   uint128_t sync_interval_;
   uint128_t log_interval_;
   bool log_oaves_;
@@ -125,6 +126,7 @@ class MapperThread
     uint128_t search_size,
     std::uint32_t timeout,
     std::uint32_t victory_condition,
+    std::int32_t max_temporal_loops_in_a_mapping,
     uint128_t sync_interval,
     uint128_t log_interval,
     bool log_oaves,

--- a/include/applications/mapper/mapper.hpp
+++ b/include/applications/mapper/mapper.hpp
@@ -63,6 +63,7 @@ class Application
   std::uint32_t num_threads_;
   std::uint32_t timeout_;
   std::uint32_t victory_condition_;
+  std::int32_t max_temporal_loops_in_a_mapping_;
   uint128_t sync_interval_;
   uint128_t log_interval_;
 

--- a/include/loop-analysis/nest-analysis-tile-info.hpp
+++ b/include/loop-analysis/nest-analysis-tile-info.hpp
@@ -139,8 +139,8 @@ struct DataMovementInfo
   std::uint64_t distributed_fanout;      // max range of fanout if distributed multicast is used.
   bool is_on_storage_boundary;
   bool is_master_spatial;
-  bool rmw_on_first_writeback;
-  bool passthrough;
+  bool rmw_first_update;
+  bool no_coalesce;
 
   void Reset();
 

--- a/include/loop-analysis/nest-analysis.hpp
+++ b/include/loop-analysis/nest-analysis.hpp
@@ -72,6 +72,7 @@ class NestAnalysis
   problem::OperationPoint cur_transform_;
 
   // per-level properties.
+  std::vector<uint64_t> utilized_spatial_elems_; // with imperfect factorization.
   std::vector<uint64_t> num_spatial_elems_;
   std::vector<uint64_t> logical_fanouts_;
 
@@ -131,13 +132,14 @@ class NestAnalysis
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse_;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback_;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_first_update_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_coalesce_;
 
   // Other state.
 
   bool working_sets_computed_ = false;
   bool imperfectly_factorized_ = false;
+  std::unordered_map<problem::Shape::FlattenedDimensionID, int> dim_imperfectly_factorized_at_;
 
   problem::Workload* workload_ = nullptr;
 
@@ -148,6 +150,7 @@ class NestAnalysis
   void ComputeWorkingSets();
 
   void DetectImperfectFactorization();
+  bool NeedsToRunImperfectIteration(std::vector<analysis::LoopState>::reverse_iterator cur);
   void InitializeNestProperties();
   void InitNumSpatialElems();
   void InitStorageBoundaries();

--- a/include/loop-analysis/tiling-tile-info.hpp
+++ b/include/loop-analysis/tiling-tile-info.hpp
@@ -127,8 +127,8 @@ struct DataMovementInfo
   std::uint64_t distributed_fanout;
   bool is_on_storage_boundary;
   bool is_master_spatial;
-  bool rmw_on_first_writeback;
-  bool passthrough;
+  bool rmw_first_update;
+  bool no_coalesce;
   //double partition_fraction;
   std::size_t partition_fraction_denominator;
   /** @brief Statistical representation of tile density */
@@ -200,8 +200,8 @@ struct DataMovementInfo
     coord_space_info.Clear();
     tile_density = NULL;
     expected_density = 0;
-    rmw_on_first_writeback = false;
-    passthrough = false;
+    rmw_first_update = false;
+    no_coalesce = false;
   }
 
   void Validate()

--- a/include/mapping/constraints.hpp
+++ b/include/mapping/constraints.hpp
@@ -65,8 +65,8 @@ class Constraints
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast_;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse_;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback_;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_first_update_;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_coalesce_;
 
  public:
   Constraints() = delete;
@@ -89,7 +89,7 @@ class Constraints
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> NoMulticast() const;
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> NoTemporalReuse() const;
   const std::unordered_map<unsigned, problem::PerDataSpace<bool>> RMWOnFirstWriteback() const;
-  const std::unordered_map<unsigned, problem::PerDataSpace<bool>> Passthrough() const;
+  const std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_coalesce() const;
 
   // Create a constraints object from a given mapping object. The resultant
   // constraints will *only* be satisfied by that mapping.

--- a/include/mapping/nest.hpp
+++ b/include/mapping/nest.hpp
@@ -98,8 +98,8 @@ class Nest
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_link_transfer;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_multicast;
   std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_temporal_reuse;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_on_first_writeback;
-  std::unordered_map<unsigned, problem::PerDataSpace<bool>> passthrough;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> rmw_first_update;
+  std::unordered_map<unsigned, problem::PerDataSpace<bool>> no_coalesce;
 
  public:
   Nest();

--- a/include/model/buffer.hpp
+++ b/include/model/buffer.hpp
@@ -208,7 +208,7 @@ class BufferLevel : public Level
   struct Stats
   {
     problem::PerDataSpace<bool> keep;
-    problem::PerDataSpace<bool> passthrough;
+    problem::PerDataSpace<bool> no_coalesce;
     problem::PerDataSpace<std::uint64_t> partition_size;
     problem::PerDataSpace<std::uint64_t> utilized_capacity;
     problem::PerDataSpace<std::uint64_t> utilized_md_capacity_bits;

--- a/include/util/numeric.hpp
+++ b/include/util/numeric.hpp
@@ -102,14 +102,14 @@ class ResidualFactors
 
   void ClearAllFactors_();
 
-  void CalculateAllFactors_();
+  void CalculateAllFactors_(unsigned long of);
 
-  void CalculateAdditionalFactors_();
+  void CalculateAdditionalFactors_(unsigned long of);
   std::vector<std::vector<unsigned long>> CartProduct_ (const std::vector<std::vector<unsigned long>> v);
 
   void GenerateFactorProduct_(const unsigned long n, const int order);
   void GenerateResidual_(const unsigned long n, const int order);
-  void ValidityChecker_(const unsigned long n, std::map<unsigned, unsigned long> given);
+  void ValidityChecker_(const unsigned long n, std::map<unsigned, unsigned long> given, std::map<unsigned, unsigned long> given_residuals);
 
   // Return a vector of all order-way cofactor sets of n.
 
@@ -119,8 +119,8 @@ class ResidualFactors
   ResidualFactors(const unsigned long n, const int order, std::vector<unsigned long> remainder_bounds, std::vector<unsigned long> remainder_ix, std::map<unsigned, unsigned long> given);
 
 
-  void PruneMax();
-  void PruneMin();
+  void PruneMax(std::map<unsigned, unsigned long>& max);
+  void PruneMin(std::map<unsigned, unsigned long>& min);
 
   std::vector<std::vector<unsigned long>> operator[](int index);
 

--- a/src/applications/mapper/mapper.cpp
+++ b/src/applications/mapper/mapper.cpp
@@ -200,6 +200,10 @@ Application::Application(config::CompoundConfig* config,
   mapper.lookupValue("log-interval", log_interval);
   log_interval_ = static_cast<uint128_t>(log_interval);
 
+  int32_t max_temporal_loops_in_a_mapping = -1;
+  mapper.lookupValue("max_temporal_loops_in_a_mapping", max_temporal_loops_in_a_mapping);
+  max_temporal_loops_in_a_mapping_ = static_cast<int32_t>(max_temporal_loops_in_a_mapping);
+
   // Misc.
   log_oaves_ = false;
   mapper.lookupValue("log-oaves", log_oaves_);
@@ -373,6 +377,7 @@ void Application::Run()
                                         search_size_,
                                         timeout_,
                                         victory_condition_,
+                                        max_temporal_loops_in_a_mapping_,
                                         sync_interval_,
                                         log_interval_,
                                         log_oaves_,

--- a/src/compound-config/compound-config.cpp
+++ b/src/compound-config/compound-config.cpp
@@ -123,7 +123,7 @@ bool CompoundConfigNode::lookupValue(const char *name, bool &value) const {
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -156,7 +156,7 @@ bool CompoundConfigNode::lookupValue(const char *name, int &value) const {
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -189,7 +189,7 @@ bool CompoundConfigNode::lookupValue(const char *name, unsigned int &value) cons
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -223,7 +223,7 @@ bool CompoundConfigNode::lookupValueLongOnly(const char *name, long long &value)
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -266,7 +266,7 @@ bool CompoundConfigNode::lookupValueLongOnly(const char *name, unsigned long lon
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -313,7 +313,7 @@ bool CompoundConfigNode::lookupValue(const char *name, double &value) const {
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }
@@ -350,7 +350,7 @@ bool CompoundConfigNode::lookupValue(const char *name, float &value) const {
       if (cConfig->getVariableRoot().exists(variableName)) {
         cConfig->getVariableRoot().lookupValue(variableName, value);
       } else {
-        std::cerr << "Cannot find " << variableName << " under root key: variables" << std::endl;
+        std::cerr << "Cannot find " << variableName << " for " << name << " under root key: variables" << std::endl;
         throw e;
       }
     }

--- a/src/mapping/constraints.cpp
+++ b/src/mapping/constraints.cpp
@@ -54,8 +54,8 @@ Constraints::Constraints(const ArchProperties& arch_props,
   no_multicast_.clear();
   no_link_transfer_.clear();
   no_temporal_reuse_.clear();
-  rmw_on_first_writeback_.clear();
-  passthrough_.clear();
+  rmw_first_update_.clear();
+  no_coalesce_.clear();
 
   // Initialize user bypass strings to "XXXXX...1" (note the 1 at the end).
   for (unsigned pvi = 0; pvi < unsigned(problem::GetShape()->NumDataSpaces); pvi++)
@@ -154,13 +154,13 @@ Constraints::NoTemporalReuse() const
 const std::unordered_map<unsigned, problem::PerDataSpace<bool>>
 Constraints::RMWOnFirstWriteback() const
 {
-  return rmw_on_first_writeback_;
+  return rmw_first_update_;
 }
 
 const std::unordered_map<unsigned, problem::PerDataSpace<bool>>
-Constraints::Passthrough() const
+Constraints::no_coalesce() const
 {
-  return passthrough_;
+  return no_coalesce_;
 }
 
 //
@@ -672,6 +672,7 @@ void Constraints::ParseSingleConstraint(
       permutations_[level_id] = level_permutations;
     }
 
+    std::vector<std::string> datatype_strings;
     if (type == "spatial")
     {
       std::uint32_t split;
@@ -692,7 +693,6 @@ void Constraints::ParseSingleConstraint(
       if (constraint.exists("no_link_transfer"))
       {
         auto storage_level = arch_props_.TilingToStorage(level_id);
-        std::vector<std::string> datatype_strings;
         constraint.lookupArrayValue("no_link_transfer", datatype_strings);
         if (no_link_transfer_.find(storage_level) != no_link_transfer_.end())
         {
@@ -720,12 +720,18 @@ void Constraints::ParseSingleConstraint(
           }
         }
       }
+
       // No multicast no reduction
-      if (constraint.exists("no_multicast_no_reduction"))
+      bool found = false;
+      datatype_strings.clear();
+      if (constraint.exists("no_reuse"))
+        found = constraint.lookupArrayValue("no_reuse", datatype_strings);
+      if (!found && constraint.exists("no_multicast_no_reduction"))
+        found = constraint.lookupArrayValue("no_multicast_no_reduction", datatype_strings);
+
+      if (found)
       {
         auto storage_level = arch_props_.TilingToStorage(level_id);
-        std::vector<std::string> datatype_strings;
-        constraint.lookupArrayValue("no_multicast_no_reduction", datatype_strings);
         if (no_multicast_.find(storage_level) != no_multicast_.end())
         {
           std::cerr << "ERROR: re-specification of no_multicast_no_reduction at level "
@@ -755,12 +761,17 @@ void Constraints::ParseSingleConstraint(
     }
     if (type == "temporal")
     {
+      bool found = false;
+      datatype_strings.clear();
+      if (constraint.exists("no_reuse"))
+        found = constraint.lookupArrayValue("no_reuse", datatype_strings);
+      if (!found && constraint.exists("no_temporal_reuse"))
+        found = constraint.lookupArrayValue("no_temporal_reuse", datatype_strings);
+
       // No temporal reuse
-      if (constraint.exists("no_temporal_reuse"))
+      if (found)
       {
         auto storage_level = arch_props_.TilingToStorage(level_id);
-        std::vector<std::string> datatype_strings;
-        constraint.lookupArrayValue("no_temporal_reuse", datatype_strings);
         if (no_temporal_reuse_.find(storage_level) != no_temporal_reuse_.end())
         {
           std::cerr << "ERROR: re-specification of no_temporal_reuse at level "
@@ -787,32 +798,32 @@ void Constraints::ParseSingleConstraint(
           }
         }
       }
-      if (constraint.exists("rmw_on_first_writeback"))
+      if (constraint.exists("rmw_first_update"))
       {
         auto storage_level = arch_props_.TilingToStorage(level_id);
         std::vector<std::string> datatype_strings;
-        constraint.lookupArrayValue("rmw_on_first_writeback", datatype_strings);
-        if (rmw_on_first_writeback_.find(storage_level) != rmw_on_first_writeback_.end())
+        constraint.lookupArrayValue("rmw_first_update", datatype_strings);
+        if (rmw_first_update_.find(storage_level) != rmw_first_update_.end())
         {
-          std::cerr << "ERROR: re-specification of rmw_on_first_writeback at level "
+          std::cerr << "ERROR: re-specification of rmw_first_update at level "
                     << arch_props_.TilingLevelName(level_id)
                     << ". This may imply a conflict between architecture and "
                     << "mapspace constraints." << std::endl;
           exit(1);
         }
-        rmw_on_first_writeback_ [storage_level] = problem::PerDataSpace<bool>();
+        rmw_first_update_ [storage_level] = problem::PerDataSpace<bool>();
         for(unsigned pv = 0; pv < problem::GetShape()->NumDataSpaces; pv++)
-          rmw_on_first_writeback_[storage_level][pv] = 0;
+          rmw_first_update_[storage_level][pv] = 0;
         for (const std::string& datatype_string: datatype_strings)
         {
           try
           {
-            rmw_on_first_writeback_[storage_level].at(
+            rmw_first_update_[storage_level].at(
               problem::GetShape()->DataSpaceNameToID.at(datatype_string)) = 1;
           }
           catch (std::out_of_range& oor)
           {
-            std::cerr << "ERROR: parsing rmw_on_first_writeback setting: data-space " << datatype_string
+            std::cerr << "ERROR: parsing rmw_first_update setting: data-space " << datatype_string
                       << " not found in problem shape." << std::endl;
             exit(1);
           }
@@ -837,32 +848,32 @@ void Constraints::ParseSingleConstraint(
   {
     // Error handling for re-spec conflicts are inside the parse function.
     ParseDatatypeBypassSettings(attributes, arch_props_.TilingToStorage(level_id));
-    if (constraint.exists("passthrough"))
+    if (constraint.exists("no_coalesce"))
     {
       auto storage_level = arch_props_.TilingToStorage(level_id);
       std::vector<std::string> datatype_strings;
-      constraint.lookupArrayValue("passthrough", datatype_strings);
-      if (passthrough_.find(storage_level) != passthrough_.end())
+      constraint.lookupArrayValue("no_coalesce", datatype_strings);
+      if (no_coalesce_.find(storage_level) != no_coalesce_.end())
       {
-        std::cerr << "ERROR: re-specification of passthrough at level "
+        std::cerr << "ERROR: re-specification of no_coalesce at level "
                   << arch_props_.TilingLevelName(level_id)
                   << ". This may imply a conflict between architecture and "
                   << "mapspace constraints." << std::endl;
         exit(1);
       }
-      passthrough_ [storage_level] = problem::PerDataSpace<bool>();
+      no_coalesce_ [storage_level] = problem::PerDataSpace<bool>();
       for(unsigned pv = 0; pv < problem::GetShape()->NumDataSpaces; pv++)
-        passthrough_[storage_level][pv] = 0;
+        no_coalesce_[storage_level][pv] = 0;
       for (const std::string& datatype_string: datatype_strings)
       {
         try
         {
-          passthrough_[storage_level].at(
+          no_coalesce_[storage_level].at(
             problem::GetShape()->DataSpaceNameToID.at(datatype_string)) = 1;
         }
         catch (std::out_of_range& oor)
         {
-          std::cerr << "ERROR: parsing passthrough setting: data-space " << datatype_string
+          std::cerr << "ERROR: parsing no_coalesce setting: data-space " << datatype_string
                     << " not found in problem shape." << std::endl;
           exit(1);
         }

--- a/src/mapspaces/ruby.cpp
+++ b/src/mapspaces/ruby.cpp
@@ -630,8 +630,8 @@ std::vector<Status> Ruby::ConstructMapping(
   mapping->loop_nest.no_link_transfer = constraints_.NoLinkTransfers();
   mapping->loop_nest.no_multicast = constraints_.NoMulticast();
   mapping->loop_nest.no_temporal_reuse = constraints_.NoTemporalReuse();
-  mapping->loop_nest.rmw_on_first_writeback = constraints_.RMWOnFirstWriteback();
-  mapping->loop_nest.passthrough = constraints_.Passthrough();
+  mapping->loop_nest.rmw_first_update = constraints_.RMWOnFirstWriteback();
+  mapping->loop_nest.no_coalesce = constraints_.no_coalesce();
 
   return status;
 }

--- a/src/mapspaces/subspaces.cpp
+++ b/src/mapspaces/subspaces.cpp
@@ -173,11 +173,11 @@ void ResidualIndexFactorizationSpace::Init(const problem::Workload &workload,
     }
 
     if (maxfactors.find(dim) != maxfactors.end())
-      dimension_factors_[idim].PruneMax();
+      dimension_factors_[idim].PruneMax(maxfactors[dim]);
 
     if (minfactors.find(dim) != minfactors.end())
-      dimension_factors_[idim].PruneMin();
-
+      dimension_factors_[idim].PruneMin(minfactors[dim]);
+    
     counter_base[idim] = dimension_factors_[idim].size();
 
   }

--- a/src/mapspaces/uber.cpp
+++ b/src/mapspaces/uber.cpp
@@ -614,8 +614,8 @@ std::vector<Status> Uber::ConstructMapping(
   mapping->loop_nest.no_link_transfer = constraints_.NoLinkTransfers();
   mapping->loop_nest.no_multicast = constraints_.NoMulticast();
   mapping->loop_nest.no_temporal_reuse = constraints_.NoTemporalReuse();
-  mapping->loop_nest.rmw_on_first_writeback = constraints_.RMWOnFirstWriteback();
-  mapping->loop_nest.passthrough = constraints_.Passthrough();
+  mapping->loop_nest.rmw_first_update = constraints_.RMWOnFirstWriteback();
+  mapping->loop_nest.no_coalesce = constraints_.no_coalesce();
 
   return status;
 }

--- a/src/model/buffer.cpp
+++ b/src/model/buffer.cpp
@@ -1157,7 +1157,7 @@ EvalStatus BufferLevel::ComputeScalarAccesses(const tiling::CompoundDataMovement
     auto pv = problem::Shape::DataSpaceID(pvi);
 
     stats_.keep[pv] = mask[pv];
-    stats_.passthrough[pv] = tile[pvi].passthrough;
+    stats_.no_coalesce[pv] = tile[pvi].no_coalesce;
 
     stats_.partition_size[pv] = tile[pvi].partition_size;
     stats_.tile_size[pv] = tile[pvi].size;
@@ -1422,8 +1422,8 @@ void BufferLevel::ComputeLeaksPerCycle(){
   for (unsigned pvi = 0; pvi < unsigned(problem::GetShape()->NumDataSpaces); pvi++)
   {
     auto pv = problem::Shape::DataSpaceID(pvi);
-    max_my_utilized = std::max(max_my_utilized, (double) stats_.utilized_x_expansion[pv] * stats_.utilized_y_expansion[pv]);
-    max_from_utilized = std::max(max_from_utilized, (double) stats_from.utilized_x_expansion[pv] * stats_from.utilized_y_expansion[pv]);
+    max_my_utilized = std::max(max_my_utilized, (double) stats_.utilized_instances[pv]);
+    max_from_utilized = std::max(max_from_utilized, (double) stats_from.utilized_instances[pv]);
   }
   stats_.n_instances_sharing_power_gating = my_instances / from_instances;
   

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -360,16 +360,16 @@ void ResidualFactors::ClearAllFactors_()
 {
   all_factors_.clear();
 }
-void ResidualFactors::CalculateAllFactors_()
+void ResidualFactors::CalculateAllFactors_(unsigned long of)
 {
-  for (unsigned long i = 1; i <= ISqrt_(n_); i++)
+  for (unsigned long i = 1; i <= ISqrt_(of); i++)
   {
-    if (n_ % i == 0)
+    if (of % i == 0)
     {
       all_factors_.insert(i);
-      if (i * i != n_)
+      if (i * i != of)
       {
-        all_factors_.insert(n_ / i);
+        all_factors_.insert(of / i);
       }
     }
   }
@@ -377,7 +377,7 @@ void ResidualFactors::CalculateAllFactors_()
 
 
 // Generate all additional potential factors given the remainder bounds  
-void ResidualFactors::CalculateAdditionalFactors_()
+void ResidualFactors::CalculateAdditionalFactors_(unsigned long of)
 {
   std::vector<unsigned long> reaminder_possible; 
   for (auto& n : remainder_bounds_){
@@ -386,16 +386,16 @@ void ResidualFactors::CalculateAdditionalFactors_()
   }
 
   for (auto& n : reaminder_possible){
-    unsigned long g = n * n_ * ceil((double)n_/(double)n);
-    for (unsigned long i = 1; i <= n_; i++)
+    unsigned long g = n * of * ceil((double)of/(double)n);
+    for (unsigned long i = 1; i <= of; i++)
     {
       if (g % i == 0)
       {
-        if (i < n_)
+        if (i < of)
         all_factors_.insert(i);
         if (i * i != g)
         {
-          if ((g/i) < n_)
+          if ((g/i) < of)
           all_factors_.insert(g / i);
         }
       }
@@ -421,20 +421,25 @@ std::vector<std::vector<unsigned long>> ResidualFactors::CartProduct_ (const std
 // Replicate all factors possibilities accross each level n, disregarding sets with that include more than dimension size n * sqrt(n)
 void ResidualFactors::GenerateFactorProduct_(const unsigned long n, const int order)
 {
+  // std::cout << "  Replicating factors across each level " << std::endl;
   for(auto rec = 0; rec < order; rec++){
     std::vector<std::vector<unsigned long>> inter_factors;
     std::vector<std::vector<unsigned long>> product_factors;
     for (auto i = 0; i < order; i++)
     {
       std::vector<unsigned long> v2;
+      // std::cout << "    trying to replicate factors for level " << i << " with remainder " << rec << std::endl;
       for(auto a : all_factors_){
         if (i == 0 && rec == 0){
+          // std::cout << "      adding factor " << a << " in condition 1" << std::endl;
           v2.push_back(a);
         }else if(a <= ((unsigned int)(pow((double)n_, 1.0/(2.0)) + 1.5)) && i > 0){
+          // std::cout << "      adding factor " << a << " in condition 2" << std::endl;
           v2.push_back(a);
         }else if (rec > 0 && i == 0 && a >= ((unsigned int)(pow((double)n_, 1.0/(2.0)) + 1.5))){
+          // std::cout << "      adding factor " << a << " in condition 3" << std::endl;
           v2.push_back(a);
-        }
+        }// else std::cout << "      skipping factor " << a << std::endl;
       }
       inter_factors.push_back(v2);
     }
@@ -446,7 +451,7 @@ void ResidualFactors::GenerateFactorProduct_(const unsigned long n, const int or
     replicated_factors_.insert(replicated_factors_.end(), product_factors.begin(), product_factors.end());
   }
 
-
+  // std::cout << " Replicated factors size " << replicated_factors_.size() << std::endl;
 
   for(auto t : replicated_factors_){
 
@@ -471,7 +476,8 @@ void ResidualFactors::GenerateResidual_(const unsigned long n, const int order)
 
   for (auto i : remainder_bounds_){
     std::vector<unsigned long> r;
-    for (unsigned j = 1; j <= i; j++){
+    // If the bound is 0, set it to 1
+    for (unsigned j = 1; j <= std::max(i, (unsigned long)1); j++){
       r.push_back(j);
     }
     residuals.push_back(r);
@@ -481,18 +487,22 @@ void ResidualFactors::GenerateResidual_(const unsigned long n, const int order)
 
   for(auto t : residuals){
     unsigned long sum = 0;
+    // std::cout << "  Residual ";
     for(auto p : t){
       sum += p;
+      // std::cout << p << " ";
     }
     if(sum <= n+(unsigned)order){
       pruned_residuals_.push_back(t);
+      // std::cout << " with sum " << sum << " accepted." << std::endl;
     }
+    // else std::cout << " with sum " << sum << " rejected." << std::endl;
   }
 
 }
 
 // Replicate all possible residual combiniations, and remove possibilities that sum up to size greater than n
-void ResidualFactors::ValidityChecker_(const unsigned long n, std::map<unsigned, unsigned long> given)
+void ResidualFactors::ValidityChecker_(const unsigned long n, std::map<unsigned, unsigned long> given, std::map<unsigned, unsigned long> given_residuals)
 {
 
   for (unsigned i = pruned_product_factors_.size(); i > 0 ; i--)
@@ -504,12 +514,11 @@ void ResidualFactors::ValidityChecker_(const unsigned long n, std::map<unsigned,
       // Insert the given factor, pushing all existing factors back.
       auto index = it->first;
       auto value = it->second;
+      // std::cout << "  Inserting given factor " << value << " at index " << index << std::endl;
       pruned_product_factors_[i-1].insert(pruned_product_factors_[i-1].begin() + index, value);
     }
-
-
   }
-  
+  for (auto it = given_residuals.begin(); it != given_residuals.end(); it++) std::cout << "";
 
   for(auto f : pruned_product_factors_){
     for(auto r : pruned_residuals_){
@@ -517,7 +526,10 @@ void ResidualFactors::ValidityChecker_(const unsigned long n, std::map<unsigned,
       int s_i = 0;
       bool valid = true;
       for(unsigned long i = 0; i < (f.size()); i++){
-        if(std::count(remainder_ix_.begin(),remainder_ix_.end(), i) > 0){
+        if(given_residuals.find(i) != given_residuals.end()){
+          valid_residuals.push_back(given_residuals.at(i));
+        }
+        else if (std::count(remainder_ix_.begin(),remainder_ix_.end(), i) > 0){
           valid_residuals.push_back(r.at(s_i));
           
           if(f.at(i) > remainder_bounds_[s_i]){
@@ -552,7 +564,7 @@ void ResidualFactors::ValidityChecker_(const unsigned long n, std::map<unsigned,
 
 }
 
-void ResidualFactors::PruneMax()
+void ResidualFactors::PruneMax(std::map<unsigned, unsigned long>& max)
 {
   // Prune the vector of cofactor sets by removing those sets that have factors
   // outside user-specified min/max range. We should really have done this during
@@ -561,10 +573,44 @@ void ResidualFactors::PruneMax()
   // find the original rank from the "compressed" rank seen by
   // MultiplicativeSplitRecursive. Doing it now is slower but cleaner and less
   // bug-prone.
-
+  auto cofactors_it = cofactors_.begin();
+  auto rfactors_it = rfactors_.begin();
+  while (cofactors_it != cofactors_.end() && rfactors_it != rfactors_.end())
+  {
+    bool illegal = false;
+    for (auto& max_factor : max)
+    {
+      auto index = max_factor.first;
+      auto max = max_factor.second;
+      assert(index <= cofactors_it->size());
+      auto value = cofactors_it->at(index);
+      if (value > max)
+      {
+        illegal = true;
+        break;
+      }
+      auto value2 = rfactors_it->at(index);
+      if (value2 > max)
+      {
+        illegal = true;
+        break;
+      }
+    }
+    if (illegal)
+    {
+      cofactors_it = cofactors_.erase(cofactors_it);
+      rfactors_it = rfactors_.erase(rfactors_it);
+    }
+    else
+    {
+      cofactors_it++;
+      rfactors_it++;
+    }
+  }
+  assert (cofactors_it == cofactors_.end() && rfactors_it == rfactors_.end());
 }
 
-void ResidualFactors::PruneMin()
+void ResidualFactors::PruneMin(std::map<unsigned, unsigned long>& min)
 {
   // Prune the vector of cofactor sets by removing those sets that have factors
   // outside user-specified min/max range. We should really have done this during
@@ -573,7 +619,43 @@ void ResidualFactors::PruneMin()
   // find the original rank from the "compressed" rank seen by
   // MultiplicativeSplitRecursive. Doing it now is slower but cleaner and less
   // bug-prone.
-
+  auto cofactors_it = cofactors_.begin();
+  auto rfactors_it = rfactors_.begin();
+  while (cofactors_it != cofactors_.end() && rfactors_it != rfactors_.end())
+  {
+    bool illegal = false;
+    for (auto& min_factor : min)
+    {
+      auto index = min_factor.first;
+      auto min = min_factor.second;
+      assert(index <= cofactors_it->size());
+      auto value = cofactors_it->at(index);
+      if (value < min)
+      {
+        // std::cout << "  cofactor " << value << " < " << min << std::endl;
+        illegal = true;
+        break;
+      }
+      auto value2 = rfactors_it->at(index);
+      if (value2 < min)
+      {
+        // std::cout << "  rfactor " << value << " < " << min << std::endl;
+        illegal = true;
+        break;
+      }
+    }
+    if (illegal)
+    {
+      cofactors_it = cofactors_.erase(cofactors_it);
+      rfactors_it = rfactors_.erase(rfactors_it);
+    }
+    else
+    {
+      cofactors_it++;
+      rfactors_it++;
+    }
+  }
+  assert (cofactors_it == cofactors_.end() && rfactors_it == rfactors_.end());
 }
 
 ResidualFactors::ResidualFactors() : n_(0) {}
@@ -587,12 +669,12 @@ ResidualFactors::ResidualFactors(const unsigned long n, const int order, std::ve
     std::vector<unsigned long> remainder_ix) : n_(n), remainder_bounds_(remainder_bounds), remainder_ix_(remainder_ix)
 {
   ClearAllFactors_();
-  CalculateAllFactors_();
-  CalculateAdditionalFactors_();
+  CalculateAllFactors_(n_);
+  CalculateAdditionalFactors_(n_);
   GenerateFactorProduct_(n, order);
   GenerateResidual_(n, order);
   std::map<unsigned, unsigned long> given = {{}};
-  ValidityChecker_(n, given);
+  ValidityChecker_(n, given, {});
 
   for (unsigned i = 0; i < cofactors_.size(); i++)
   {
@@ -605,65 +687,54 @@ ResidualFactors::ResidualFactors(const unsigned long n, const int order, std::ve
     std::vector<unsigned long> remainder_ix, std::map<unsigned, unsigned long> given)
     : n_(n), remainder_bounds_(remainder_bounds), remainder_ix_(remainder_ix)
 {
-
   const unsigned int given_size = given.size();
+  std::map<unsigned, unsigned long> given_residuals;
 
   assert(given_size <= std::size_t(order));
-  // If any of the given factors is not a factor of n, forcibly reset that to
-  // be a free variable, otherwise accumulate them into a partial product.
   unsigned long partial_product = 1;
+  unsigned long remaining = n;
+  // std::cout << "Given factors: ";
   for (auto f = given.begin(); f != given.end(); f++)
   {
     auto factor = f->second;
-    if (n % (factor * partial_product) == 0)
+    // std::cout << "[" << f->first << "]=" << factor << " ";
+    if (remaining % factor == 0)
     {
       partial_product *= factor;
+      remaining /= factor;
+    }
+    else if (factor > remaining)
+    {
+      // std::cout << "Factor " << f->first << "=" << factor << " > remaining " << remaining << ". Setting factor to " << remaining << "." << std::endl;
+      f->second = remaining;
+      partial_product *= remaining;
+      given[f->first] = remaining;
+      remaining = 1;
     }
     else
     {
-      std::cerr << "WARNING: cannot accept " << factor << " as a factor of " << n
-                << " with current partial product " << partial_product;
-#define SET_NONFACTOR_TO_FREE_VARIABLE
-#ifdef SET_NONFACTOR_TO_FREE_VARIABLE
-      // Ignore mapping constraint and set the factor to a free variable.
-      std::cerr << ", ignoring mapping constraint and setting to a free variable."
-                << std::endl;
-      f = given.erase(f);
-#else       
-      // Try to find the next *lower* integer that is a factor of n.
-      // FIXME: there are multiple exceptions that can cause us to be here:
-      // (a) factor doesn't divide into n.
-      // (b) factor does divide into n but causes partial product to exceed n.
-      // (c) factor does divide into n but causes partial product to not
-      //     divide into n.
-      // The following code only solves case (a).
-      std::cerr << "FIXME: please fix this code." << std::endl;
-      assert(false);
-      
-      for (; factor >= 1 && (n % factor != 0); factor--);
-      std::cerr << ", setting this to " << factor << " instead." << std::endl;
-      f->second = factor;
+      // Do a cieling division to find the next *higher* integer that is a factor of n.
+
       partial_product *= factor;
-#endif
+      std::cout << "Imperfect constraint detected. Factor " << f->first << "=" << factor << " has residual " << remaining % factor << "." << std::endl;
+      given_residuals[f->first] = remaining % factor;
+      remaining = ceil((double)remaining/(double)factor);
     }
-    assert(n % partial_product == 0);
   }
-
   ClearAllFactors_();
-  CalculateAllFactors_();
-  CalculateAdditionalFactors_();
-
-
-
-  GenerateFactorProduct_(n / partial_product, order - given.size());
-
-  GenerateResidual_(n / partial_product, order - given.size());
+  CalculateAllFactors_(remaining);
+  CalculateAdditionalFactors_(remaining);
+  
+  auto new_order = order - given.size();
+  new_order = new_order < 1 ? 1 : new_order;
+  
+  GenerateFactorProduct_(remaining, new_order);
+  GenerateResidual_(remaining, new_order);
   
 
 
   // Insert the given factors at the specified indices of each of the solutions.
-
-  ValidityChecker_(n, given);
+  ValidityChecker_(n, given, given_residuals);
 
   remainder_bounds_.resize(0);
   remainder_ix_.resize(0);

--- a/src/util/numeric.cpp
+++ b/src/util/numeric.cpp
@@ -691,7 +691,6 @@ ResidualFactors::ResidualFactors(const unsigned long n, const int order, std::ve
   std::map<unsigned, unsigned long> given_residuals;
 
   assert(given_size <= std::size_t(order));
-  unsigned long partial_product = 1;
   unsigned long remaining = n;
   // std::cout << "Given factors: ";
   for (auto f = given.begin(); f != given.end(); f++)
@@ -700,22 +699,18 @@ ResidualFactors::ResidualFactors(const unsigned long n, const int order, std::ve
     // std::cout << "[" << f->first << "]=" << factor << " ";
     if (remaining % factor == 0)
     {
-      partial_product *= factor;
       remaining /= factor;
     }
     else if (factor > remaining)
     {
       // std::cout << "Factor " << f->first << "=" << factor << " > remaining " << remaining << ". Setting factor to " << remaining << "." << std::endl;
       f->second = remaining;
-      partial_product *= remaining;
       given[f->first] = remaining;
       remaining = 1;
     }
     else
     {
-      // Do a cieling division to find the next *higher* integer that is a factor of n.
-
-      partial_product *= factor;
+      // Do a ceiling division to find the next *higher* integer that is a factor of n.
       std::cout << "Imperfect constraint detected. Factor " << f->first << "=" << factor << " has residual " << remaining % factor << "." << std::endl;
       given_residuals[f->first] = remaining % factor;
       remaining = ceil((double)remaining/(double)factor);


### PR DESCRIPTION
Per mapping speed is orders-of-magnitude faster
Imperfect factors give orders-of-magnitude smaller mapspaces
Ruby bug fix
New Directives:
- rmw_first_update (refactored rmw_on_first_writeback)
- no_coalesce (refactored passthrough)
- max_temporal_loops_in_a_mapping