### PR TITLE
Fix Ruby incorrect utilized_spatial_elems_

### DIFF
--- a/include/loop-analysis/nest-analysis.hpp
+++ b/include/loop-analysis/nest-analysis.hpp
@@ -72,7 +72,7 @@ class NestAnalysis
   problem::OperationPoint cur_transform_;
 
   // per-level properties.
-  std::vector<uint64_t> utilized_spatial_elems_; // with imperfect factorization.
+  std::vector<double> utilized_spatial_elems_; // with imperfect factorization.
   std::vector<uint64_t> num_spatial_elems_;
   std::vector<uint64_t> logical_fanouts_;
 

--- a/include/loop-analysis/tiling-tile-info.hpp
+++ b/include/loop-analysis/tiling-tile-info.hpp
@@ -116,7 +116,7 @@ struct DataMovementInfo
   
   std::vector<loop::Descriptor> subnest;
   /** @brief Number of spatial elements at this level. */
-  std::uint64_t replication_factor;
+  double replication_factor;
   double        avg_replication_factor;
   std::uint64_t max_replication_factor;
   std::uint64_t max_x_expansion;
@@ -287,7 +287,7 @@ struct DataMovementInfo
 
 struct ComputeInfo
 {
-  std::uint64_t replication_factor;      // number of spatial elements at this level.
+  double replication_factor;      // number of spatial elements at this level.
   double accesses;
   double avg_replication_factor;
   std::uint64_t max_replication_factor;


### PR DESCRIPTION
The bug: Previously, imperfectly-factorized spatial loops would use residual values every time the ONE loop above was it.
```
for X in [0..3):
  for X in [0..3):
    spatial-for X in [0..3, 1): // <-- Triggered three times instead of 1
``` 

This was a significant bug because mappings missed significant numbers of computes (up to 80% error). 

Fixed with some new logic. Tested with deep loop nests of many imperfectly-factorized loops. Still 0-0.2% error in total #computes... likely due to rounding errors somewhere.