### PR TITLE
[isl-spatial-analysis] Add unicast hops calculation

### DIFF
--- a/include/loop-analysis/spatial-analysis.hpp
+++ b/include/loop-analysis/spatial-analysis.hpp
@@ -26,6 +26,7 @@ struct TransferInfo
   {
     double accesses;
     double hops;
+    double unicast_hops;
   };
   std::map<std::pair<uint64_t, uint64_t>, AccessStats> compat_access_stats;
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -303,6 +303,7 @@ applications/looptree-model/main.cpp
 
 unit_test_sources = Split("""
 unit-tests/test-main.cpp
+unit-tests/test-multicast.cpp
 unit-tests/test-simple-link-transfer.cpp
 """)
 

--- a/src/loop-analysis/isl-analysis/isl-to-legacy-adaptor.cpp
+++ b/src/loop-analysis/isl-analysis/isl-to-legacy-adaptor.cpp
@@ -190,7 +190,8 @@ CompoundDataMovementNest GenerateCompoundDataMovementNest(
         {
           tile.access_stats.stats[key] = AccessStats{
             .accesses = access_stats.accesses / tile.replication_factor,
-            .hops = access_stats.hops
+            .hops = access_stats.hops,
+            .unicast_hops = access_stats.unicast_hops
           };
         }
 

--- a/src/unit-tests/test-multicast.cpp
+++ b/src/unit-tests/test-multicast.cpp
@@ -8,10 +8,11 @@ BOOST_AUTO_TEST_CASE(TestSimpleMulticastModel)
   using namespace analysis;
 
   /* Graphically:
-   *  ------------ t
-   *  ---- x     ---- x 
+   *  ------------> t
+   *  ----> x     ----> x 
    * | [0] [1]   | [1] [2]
    * | [1] [2]   | [2] [3]
+   * v           v
    * y           y        
    */
   auto fill = Fill(
@@ -29,12 +30,9 @@ BOOST_AUTO_TEST_CASE(TestSimpleMulticastModel)
   auto info = multicast_model.Apply(fill, occ);
 
   auto& singles = info.compat_access_stats.at(std::make_pair(1, 1));
-  BOOST_CHECK(singles.accesses == 2);
-  BOOST_CHECK(singles.hops == 4);
-
-  auto& doubles = info.compat_access_stats.at(std::make_pair(2, 1));
-  BOOST_CHECK(doubles.accesses == 4);
-  BOOST_CHECK(doubles.hops == 3.5);
+  BOOST_CHECK_CLOSE(singles.accesses, 6, 0.1);
+  BOOST_CHECK_CLOSE(singles.hops, 22.0/6, 0.1);
+  BOOST_CHECK_CLOSE(singles.unicast_hops, 4, 0.1);
 }
 
 BOOST_AUTO_TEST_CASE(TestSimpleMulticastModel_FlattenedCoords)
@@ -64,8 +62,7 @@ BOOST_AUTO_TEST_CASE(TestSimpleMulticastModel_FlattenedCoords)
   auto info = multicast_model.Apply(fill, occ);
 
   auto& singles = info.compat_access_stats.at(std::make_pair(1, 1));
-  BOOST_CHECK(singles.accesses == 4);
-
-  auto& doubles = info.compat_access_stats.at(std::make_pair(2, 1));
-  BOOST_CHECK(doubles.accesses == 4);
+  BOOST_CHECK_CLOSE(singles.accesses, 6, 0.1);
+  BOOST_CHECK_CLOSE(singles.hops, 29.0/6, 0.1);
+  BOOST_CHECK_CLOSE(singles.unicast_hops, 32.0/6, 0.1);
 }


### PR DESCRIPTION
This PR adds unicast hops calculation into the ISL nest analysis path. Specifically, the PR adds:

1. An analysis inside ISL multicast analysis that computes unicast hops.
2. A member in the ISL analysis output data structure to hold the unicast hops.
3. Update to the ISL analysis output to nest analysis data structure adaptor to pass along the unicast hops value.
4. Update to the unit test for ISL multicast analysis to test the new analysis.