### PR TITLE
Include the Mapper and Model applications in a library.

### DIFF
--- a/include/applications/design-space/design-space.hpp
+++ b/include/applications/design-space/design-space.hpp
@@ -67,7 +67,7 @@ class DesignSpaceExplorer
   std::string archspec_filename_;
 
   std::vector<PointResult> designs_;
-  std::vector<Application*> mappers_;
+  std::vector<application::Mapper*> mappers_;
 
  public:
 

--- a/include/applications/mapper/mapper.hpp
+++ b/include/applications/mapper/mapper.hpp
@@ -44,7 +44,10 @@
 //                Application                 //
 //--------------------------------------------//
 
-class Application
+namespace application
+{
+
+class Mapper
 {
  public:
   std::string name_;
@@ -93,18 +96,19 @@ class Application
 
  public:
 
-  Application(config::CompoundConfig* config,
-              std::string output_dir = ".",
-              std::string name = "timeloop-mapper");
+  Mapper(config::CompoundConfig* config,
+         std::string output_dir = ".",
+         std::string name = "timeloop-mapper");
 
   // This class does not support being copied
-  Application(const Application&) = delete;
-  Application& operator=(const Application&) = delete;
+  Mapper(const Mapper&) = delete;
+  Mapper& operator=(const Mapper&) = delete;
 
-  ~Application();
+  ~Mapper();
 
   EvaluationResult GetGlobalBest();
 
   void Run();
 };
 
+} // namespace application

--- a/include/applications/mapper/mapper.hpp
+++ b/include/applications/mapper/mapper.hpp
@@ -52,6 +52,22 @@ class Mapper
  public:
   std::string name_;
 
+  /**
+   * @brief Contains string versions of the output that used to print to file
+   *   during a call to `Run()`. Instead, this is returned so that `main()` can
+   *   print to file instead.
+   */
+  struct Result
+  {
+    std::string mapping_cpp_string;
+    std::string mapping_yaml_string;
+    std::string mapping_string;
+    std::string stats_string;
+    std::string tensella_string;
+    std::string xml_mapping_stats_string;
+    std::string oaves_string;
+  };
+
  protected:
 
   problem::Workload workload_;
@@ -108,7 +124,7 @@ class Mapper
 
   EvaluationResult GetGlobalBest();
 
-  void Run();
+  Mapper::Result Run();
 };
 
 } // namespace application

--- a/include/applications/model/model.hpp
+++ b/include/applications/model/model.hpp
@@ -58,6 +58,11 @@ class Model
   {
     double energy;
     double cycles;
+
+    std::string stats_string;
+    std::string map_string;
+    std::string xml_map_and_stats_string;
+    std::string tensella_string;
   };
 
  protected:

--- a/include/applications/model/model.hpp
+++ b/include/applications/model/model.hpp
@@ -46,7 +46,10 @@
 //                Application                 //
 //--------------------------------------------//
 
-class Application
+namespace application
+{
+
+class Model
 {
  public:
   std::string name_;
@@ -92,17 +95,19 @@ class Application
 
  public:
 
-  Application(config::CompoundConfig* config,
-              std::string output_dir = ".",
-              std::string name = "timeloop-model");
+  Model(config::CompoundConfig* config,
+        std::string output_dir = ".",
+        std::string name = "timeloop-model");
 
   // This class does not support being copied
-  Application(const Application&) = delete;
-  Application& operator=(const Application&) = delete;
+  Model(const Model&) = delete;
+  Model& operator=(const Model&) = delete;
 
-  ~Application();
+  ~Model();
 
   // Run the evaluation.
   Stats Run();
 };
 
+
+} // namespace application

--- a/src/SConscript
+++ b/src/SConscript
@@ -307,6 +307,19 @@ unit-tests/test-multicast.cpp
 unit-tests/test-simple-link-transfer.cpp
 """)
 
+application_sources = Split("""
+applications/model/model.cpp
+applications/mapper/mapper.cpp
+applications/mapper/mapper-thread.cpp
+""")
+
+if GetOption('link_static'):
+    lib_applications_static = libenv.StaticLibrary(target = 'timeloop-applications', source = application_sources)
+    libenv.Install(env['BUILD_BASE_DIR'] + '/lib', [ lib_applications_static ])
+else:
+    lib_applications_shared = libenv.SharedLibrary(target = 'timeloop-applications', source = application_sources)
+    libenv.Install(env['BUILD_BASE_DIR'] + '/lib', [ lib_applications_shared ])
+
 bin_metrics = env.Program(target = 'timeloop-metrics', source = metrics_sources)
 bin_model = env.Program(target = 'timeloop-model', source = model_sources)
 bin_simple_mapper = env.Program(target = 'timeloop-simple-mapper', source = simple_mapper_sources)

--- a/src/SConscript
+++ b/src/SConscript
@@ -217,6 +217,7 @@ mapping/mapping.cpp
 mapping/parser.cpp
 mapping/arch-properties.cpp
 mapping/constraints.cpp
+applications/model/model.cpp
 """)
 
 mapspace_sources = Split("""
@@ -236,7 +237,15 @@ search/random-pruned.cpp
 search/random.cpp
 """)
 
-mapperlib_sources = modellib_sources + mapspace_sources + search_sources
+mapper_application_sources = Split("""
+applications/mapper/mapper.cpp
+applications/mapper/mapper-thread.cpp
+""")
+
+mapperlib_sources = (modellib_sources +
+                     mapspace_sources +
+                     search_sources +
+                     mapper_application_sources)
 
 libenv = env.Clone()
 
@@ -273,8 +282,6 @@ applications/model/main.cpp
 """)
 
 mapper_sources = Split("""
-applications/mapper/mapper.cpp
-applications/mapper/mapper-thread.cpp
 applications/mapper/main.cpp
 """)
 
@@ -312,13 +319,6 @@ applications/model/model.cpp
 applications/mapper/mapper.cpp
 applications/mapper/mapper-thread.cpp
 """)
-
-if GetOption('link_static'):
-    lib_applications_static = libenv.StaticLibrary(target = 'timeloop-applications', source = application_sources)
-    libenv.Install(env['BUILD_BASE_DIR'] + '/lib', [ lib_applications_static ])
-else:
-    lib_applications_shared = libenv.SharedLibrary(target = 'timeloop-applications', source = application_sources)
-    libenv.Install(env['BUILD_BASE_DIR'] + '/lib', [ lib_applications_shared ])
 
 bin_metrics = env.Program(target = 'timeloop-metrics', source = metrics_sources)
 bin_model = env.Program(target = 'timeloop-model', source = model_sources)

--- a/src/applications/design-space/design-space.cpp
+++ b/src/applications/design-space/design-space.cpp
@@ -140,7 +140,7 @@ void DesignSpaceExplorer::Run()
       config::CompoundConfig config("temp_dse.yaml");
 
       //std::cout << "arch yaml: \n" << curr_arch.yaml_ << std::endl;
-      Application* mapper = new Application(&config, file_name);
+      application::Mapper* mapper = new application::Mapper(&config, file_name);
       //SimpleMapper mapper = SimpleMapper(config_name, arch, problem);
       mapper->Run();
       PointResult result(mapper->name_, mapper->GetGlobalBest());

--- a/src/applications/mapper/main.cpp
+++ b/src/applications/mapper/main.cpp
@@ -96,7 +96,7 @@ int main(int argc, char* argv[])
   const auto result = application.Run();
 
   // Output file names.
-  std::string out_prefix = output_dir + "timeloop-mapper";
+  std::string out_prefix = output_dir + "/" + "timeloop-mapper";
 
   const auto fname_to_string = std::map<std::string, const std::string&>({
     {"stats.txt", result.stats_string},

--- a/src/applications/mapper/main.cpp
+++ b/src/applications/mapper/main.cpp
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
   }
   std::cout << std::endl;
   
-  Application application(config, output_dir);
+  application::Mapper application(config, output_dir);
   
   application.Run();
 

--- a/src/applications/mapper/main.cpp
+++ b/src/applications/mapper/main.cpp
@@ -93,7 +93,27 @@ int main(int argc, char* argv[])
   
   application::Mapper application(config, output_dir);
   
-  application.Run();
+  const auto result = application.Run();
+
+  // Output file names.
+  std::string out_prefix = output_dir + "timeloop-mapper";
+
+  const auto fname_to_string = std::map<std::string, const std::string&>({
+    {"stats.txt", result.stats_string},
+    {"map+stats.xml", result.xml_mapping_stats_string},
+    {"map.txt", result.mapping_string},
+    {"map.yaml", result.mapping_yaml_string},
+    {"map.cpp", result.mapping_cpp_string},
+    {"map.tensella.txt", result.tensella_string},
+    {"oaves.csv", result.oaves_string}
+  });
+
+  for (const auto& [fname_suffix, content_string] : fname_to_string)
+  {
+    std::ofstream file(out_prefix + "." + fname_suffix);
+    file << content_string;
+    file.close();
+  }
 
   return 0;
 }

--- a/src/applications/mapper/mapper.cpp
+++ b/src/applications/mapper/mapper.cpp
@@ -39,8 +39,11 @@
 //                Application                 //
 //--------------------------------------------//
 
+namespace application
+{
+
 template <class Archive>
-void Application::serialize(Archive& ar, const unsigned int version)
+void Mapper::serialize(Archive& ar, const unsigned int version)
 {
   if(version == 0)
   {
@@ -48,9 +51,9 @@ void Application::serialize(Archive& ar, const unsigned int version)
   }
 }
 
-Application::Application(config::CompoundConfig* config,
-                         std::string output_dir,
-                         std::string name) :
+Mapper::Mapper(config::CompoundConfig* config,
+               std::string output_dir,
+               std::string name) :
     name_(name)
 {
   auto rootNode = config->getRoot();
@@ -297,7 +300,7 @@ Application::Application(config::CompoundConfig* config,
 
 }
 
-Application::~Application()
+Mapper::~Mapper()
 {
   if (mapspace_)
   {
@@ -318,7 +321,7 @@ Application::~Application()
   }
 }
 
-EvaluationResult Application::GetGlobalBest()
+EvaluationResult Mapper::GetGlobalBest()
 {
   return global_best_;
 }
@@ -326,7 +329,7 @@ EvaluationResult Application::GetGlobalBest()
 // ---------------
 // Run the mapper.
 // ---------------
-void Application::Run()
+void Mapper::Run()
 {
   // Output file names.
   std::string log_file_name = out_prefix_ + ".log";
@@ -590,7 +593,7 @@ void Application::Run()
     boost::archive::xml_oarchive ar(ofs);
     ar << boost::serialization::make_nvp("engine", engine);
     ar << boost::serialization::make_nvp("mapping", global_best_.mapping);
-    const Application* a = this;
+    const Mapper* a = this;
     ar << BOOST_SERIALIZATION_NVP(a);
 
     // Print the mapping in Tenssella input format.
@@ -697,3 +700,5 @@ void Application::Run()
     config.writeFile(map_cfg_file_name.c_str());
   }
 }
+
+} // namespace application

--- a/src/applications/mapper/mapper.cpp
+++ b/src/applications/mapper/mapper.cpp
@@ -334,6 +334,7 @@ Mapper::Result Mapper::Run()
   // Output file names.
   std::string log_file_name = out_prefix_ + ".log";
   std::string map_cfg_file_name = out_prefix_ + ".map.cfg";
+  std::string oaves_prefix = out_prefix_ + ".oaves";
 
   // Prepare live status/log stream.
   std::ofstream log_file;
@@ -693,6 +694,7 @@ Mapper::Result Mapper::Run()
   result.stats_string = stats_str.str();
   result.tensella_string = tensella_str.str();
   result.xml_mapping_stats_string = xml_map_stats_str.str();
+  result.oaves_string = oaves_stream.str();
 
   return result;
 }

--- a/src/applications/model/main.cpp
+++ b/src/applications/model/main.cpp
@@ -82,7 +82,7 @@ int main(int argc, char* argv[])
   const auto stats = application.Run();
 
   // Output file names.
-  std::string out_prefix = output_dir + "timeloop-model";
+  std::string out_prefix = output_dir + "/" + "timeloop-model";
 
   const auto fname_to_string = std::map<std::string, const std::string&>({
     {"stats.txt", stats.stats_string},

--- a/src/applications/model/main.cpp
+++ b/src/applications/model/main.cpp
@@ -79,7 +79,24 @@ int main(int argc, char* argv[])
 
   application::Model application(config, output_dir);
   
-  application.Run();
+  const auto stats = application.Run();
+
+  // Output file names.
+  std::string out_prefix = output_dir + "timeloop-model";
+
+  const auto fname_to_string = std::map<std::string, const std::string&>({
+    {"stats.txt", stats.stats_string},
+    {"map+stats.xml", stats.xml_map_and_stats_string},
+    {"map.txt", stats.map_string},
+    {"map.tensella.txt", stats.tensella_string}
+  });
+
+  for (const auto& [fname_suffix, content_string] : fname_to_string)
+  {
+    std::ofstream file(out_prefix + "." + fname_suffix);
+    file << content_string;
+    file.close();
+  }
 
   return 0;
 }

--- a/src/applications/model/main.cpp
+++ b/src/applications/model/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 
   auto config = new config::CompoundConfig(input_files);
 
-  Application application(config, output_dir);
+  application::Model application(config, output_dir);
   
   application.Run();
 

--- a/src/applications/model/model.cpp
+++ b/src/applications/model/model.cpp
@@ -36,8 +36,11 @@
 //                Application                 //
 //--------------------------------------------//
 
+namespace application
+{
+
 template <class Archive>
-void Application::serialize(Archive& ar, const unsigned int version)
+void Model::serialize(Archive& ar, const unsigned int version)
 {
   if (version == 0)
   {
@@ -45,9 +48,9 @@ void Application::serialize(Archive& ar, const unsigned int version)
   }
 }
 
-Application::Application(config::CompoundConfig* config,
-                         std::string output_dir,
-                         std::string name) :
+Model::Model(config::CompoundConfig* config,
+             std::string output_dir,
+             std::string name) :
     name_(name)
 {    
   auto rootNode = config->getRoot();
@@ -183,7 +186,7 @@ Application::Application(config::CompoundConfig* config,
   }
 }
 
-Application::~Application()
+Model::~Model()
 {
   if (mapping_)
     delete mapping_;
@@ -199,7 +202,7 @@ Application::~Application()
 }
 
 // Run the evaluation.
-Application::Stats Application::Run()
+Model::Stats Model::Run()
 {
   // Output file names.
   std::string stats_file_name = out_prefix_ + ".stats.txt";
@@ -285,7 +288,7 @@ Application::Stats Application::Run()
   boost::archive::xml_oarchive ar(ofs);
   ar << BOOST_SERIALIZATION_NVP(engine);
   ar << BOOST_SERIALIZATION_NVP(mapping);
-  const Application* a = this;
+  const Model* a = this;
   ar << BOOST_SERIALIZATION_NVP(a);
 
   // Print the mapping in Tenssella input format.
@@ -297,3 +300,5 @@ Application::Stats Application::Run()
   stats.energy = engine.Energy();
   return stats;
 }
+
+} // namespace application


### PR DESCRIPTION
Include the Mapper and Model applications in a new library by:

1. Rename the applications from `Application` to `application::Mapper` or `application::Model` to avoid name collision. This also adds the `application` namespace.
2. Include the sources for the mapper and model in a new library, called `timeloop-applications`.

Note that code that links to `timeloop-applications` also needs to link to `timeloop-mapper`.

**Known Issues**
- Writing to files does not seem to work well (at least, as is) when calling from Python through PyBind11. A solution is to refactor the part of `Run()` that writes to files and just don't call that in the Python version.