### PR TITLE
Ruby Mapper Fix

### DIFF
--- a/src/mapping/loop.cpp
+++ b/src/mapping/loop.cpp
@@ -169,7 +169,7 @@ std::string Descriptor::PrintCompact(const std::map<problem::Shape::FlattenedDim
   std::ostringstream str;
   str << id_to_name.at(dimension) << end;
   if (residual_end != end)
-    str << "," << residual_end;
+    str << ";" << residual_end;
   if (IsSpatial(spacetime_dimension))
   {
     if (IsSpatialX(spacetime_dimension))

--- a/src/mapspaces/ruby.cpp
+++ b/src/mapspaces/ruby.cpp
@@ -102,6 +102,7 @@ void Ruby::Init(config::CompoundConfigNode config, config::CompoundConfigNode ar
     
   // Check for integer overflow in the above multiplications.
   uint128_t de_cumulative_prod = Size();
+
   for (int i = 0; i < int(mapspace::Dimension::Num); i++)
   {
     de_cumulative_prod /= size_[i];
@@ -207,7 +208,7 @@ void Ruby::InitIndexFactorizationSpace()
   // Find spatial levels and their fanouts
   std::vector<unsigned long int> remainders;
   std::vector<unsigned long int> remainders_ix;
-  for (uint64_t level = arch_props_.TilingLevels(); level >= 1; level--)
+  for (int64_t level = arch_props_.TilingLevels(); level >= 0; level--)
   {
 
     // Extract the user-provided remainders for this level.
@@ -456,10 +457,10 @@ void Ruby::InitPruned(uint128_t index_factorization_id)
         auto dim = problem::Shape::FlattenedDimensionID(idim);
         auto factor = index_factorization_space_.GetFactor(
           mapping_index_factorization_id, dim, level);
-        // if (factor == 1)
-        // {
-        //   pruned_dimensions[level].push_back(dim);
-        // }
+        if (factor.at(0) == 1 && factor.at(1) == 1)
+        {
+          pruned_dimensions[level].push_back(dim);
+        }
       }
     }
     unit_factors[level] = pruned_dimensions[level].size();


### PR DESCRIPTION
1. Fix ruby mapper with remainder constraint taken from the lowest memory level; 
2. Eneable pruning for factor size 1, remainder 1 
3. Change the residual print comma to a semicolon to make it compatible with csv dump for orojenesis

To enable the ruby mapper, we first need to specify the maximum remainder at the target tmemory level, e.g., 
```
mapspace:
   version: 0.4
   template: "ruby"
   targets:
    - target: Buffer
     type: temporal
     remainders: 10
```